### PR TITLE
add a test for connected components

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -23,7 +23,7 @@ import org.apache.spark.Logging
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.sql.SQLHelpers._
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{array, col, count, explode, monotonicallyIncreasingId, struct}
+import org.apache.spark.sql.functions.{array, col, count, explode, struct}
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -416,8 +416,8 @@ class GraphFrame private(
       val indexedVertices = vertices.select(nestAsCol(vertices, ATTR))
       indexedVertices.select(col(ATTR + "." + ID).as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
-      val indexedVertices = vertices.select(monotonicallyIncreasingId().as(LONG_ID), nestAsCol(vertices, ATTR))
-      indexedVertices.select(col(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
+      val indexedVertices = zipWithUniqueId(vertices)
+      indexedVertices.select(col("uniq_id").as(LONG_ID), col("row." + ID).as(ID), col("row").as(ATTR))
     }
   }
 

--- a/src/main/spark-1.4/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-1.4/org/apache/spark/sql/SQLHelpers.scala
@@ -31,7 +31,7 @@ object SQLHelpers {
 
   /**
    * A patched version of [[org.apache.spark.sql.execution.expressions.MonotonicallyIncreasingID()]]
-   * that works for local relations in Spark 1.4.
+   * that works for local relations in Spark 1.4. (SPARK-9020)
    */
   private case class PatchedMonotonicallyIncreasingID() extends LeafExpression {
 

--- a/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
@@ -18,12 +18,19 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.Expression
-
+import org.apache.spark.sql.functions
 
 object SQLHelpers {
   def getExpr(col: Column): Expression = col.expr
 
   def expr(e: String): Column = functions.expr(e)
 
-  def monotonicallyIncreasingId(): Column = functions.monotonicallyIncreasingId()
+  /**
+   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
+   */
+  def zipWithUniqueId(df: DataFrame): DataFrame = {
+    df.select(
+      struct(df.columns.map(c => df(c)) :_*).as("row"),
+      functions.monotonicallyIncreasingId().as("uniq_id"))
+  }
 }

--- a/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.functions
+
 
 object SQLHelpers {
   def getExpr(col: Column): Expression = col.expr
@@ -30,7 +30,7 @@ object SQLHelpers {
    */
   def zipWithUniqueId(df: DataFrame): DataFrame = {
     df.select(
-      struct(df.columns.map(c => df(c)) :_*).as("row"),
+      functions.struct(df.columns.map(c => df(c)) :_*).as("row"),
       functions.monotonicallyIncreasingId().as("uniq_id"))
   }
 }

--- a/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-x/org/apache/spark/sql/SQLHelpers.scala
@@ -24,4 +24,6 @@ object SQLHelpers {
   def getExpr(col: Column): Expression = col.expr
 
   def expr(e: String): Column = functions.expr(e)
+
+  def monotonicallyIncreasingId(): Column = functions.monotonicallyIncreasingId()
 }

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -41,12 +41,8 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
   override def beforeAll(): Unit = {
     super.beforeAll()
     tempDir = Files.createTempDir()
-    // Note: We use non-local DataFrames because of a bug in Spark 1.4 which prevents us from
-    //       using monotonicallyIncreasingID: SPARK-9020
-    //       This fix in 1.5 will not be backported to 1.4, but we could fix it by having two
-    //       implementations of indexing in GraphFrame.toGraphX.
-    vertices = sqlContext.createDataFrame(sc.parallelize(localVertices.toSeq)).toDF("id", "name")
-    edges = sqlContext.createDataFrame(sc.parallelize(localEdges.toSeq).map {
+    vertices = sqlContext.createDataFrame(localVertices.toSeq).toDF("id", "name")
+    edges = sqlContext.createDataFrame(localEdges.toSeq.map {
       case ((src, dst), action) =>
         (src, dst, action)
     }).toDF("src", "dst", "action")

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -146,7 +146,7 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     }
   }
 
-  ignore("convert to GraphX: String IDs") {
+  test("convert to GraphX: String IDs") {
     try {
       val vv = vertices.select(col("id").cast(StringType).as("id"), col("name"))
       val ee = edges.select(col("src").cast(StringType).as("src"),

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -19,7 +19,7 @@ package org.graphframes.lib
 
 import org.apache.spark.sql.Row
 
-import org.graphframes.{GraphFrameTestSparkContext, GraphFrame, SparkFunSuite}
+import org.graphframes.{GraphFrameTestSparkContext, GraphFrame, SparkFunSuite, examples}
 
 
 class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
@@ -53,4 +53,8 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     assert(List(Row(0L, 0L, "a0", "b0"), Row(1L, 0L, "a1", "b1")) === vxs)
   }
 
+  test("fiends graph") {
+    val friends = examples.Graphs.friends
+    friends.connectedComponents.run()
+  }
 }


### PR DESCRIPTION
This triggers a NPE on Spark 1.4 notebook. Let's try Travis.

`monotonicallyIncreasingId` is not correctly implemented in Spark 1.4, which doesn't work for local relations, nor guarantees deterministic output. So for Spark 1.4, we switch to RDD explicitly to generate unique IDs. This may have performance issues, but works.