### PR TITLE
triangle count should not return nulls

### DIFF
--- a/src/main/scala/org/graphframes/lib/TriangleCount.scala
+++ b/src/main/scala/org/graphframes/lib/TriangleCount.scala
@@ -74,10 +74,9 @@ private object TriangleCount {
       .unionAll(cycles.select(col("a").as(ID)))
     val triangleCounts = allTriangles.groupBy(ID).count()
     val v = graph.vertices
-    val countsCol = when(triangleCounts("count").isNotNull, triangleCounts("count"))
-      .otherwise(0).as(COUNT_ID)
+    val countsCol = when(col("count").isNull, 0L).otherwise(col("count"))
     val newV = v.join(triangleCounts, v(ID) === triangleCounts(ID), "left_outer")
-      .select(countsCol +: v.columns.map(v.apply) :_ *)
+      .select(countsCol.as(COUNT_ID) +: v.columns.map(v.apply) :_ *)
     GraphFrame(newV, graph.edges)
   }
 

--- a/src/test/scala/org/graphframes/lib/TriangleCountSuite.scala
+++ b/src/test/scala/org/graphframes/lib/TriangleCountSuite.scala
@@ -73,4 +73,13 @@ class TriangleCountSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       assert(count === 1)
     }
   }
+
+  test("no triangles") {
+    val edges = sqlContext.createDataFrame(Array(0L -> 1L, 1L -> 2L)).toDF("src", "dst")
+    val g = GraphFrame.fromEdges(edges)
+    val g2 = g.triangleCount.run()
+    g2.vertices.select("count").collect().foreach { case Row(count: Long) =>
+      assert(count === 0)
+    }
+  }
 }


### PR DESCRIPTION
`triangleCounts("count").isNotNull` is always false through static analysis.