### PR TITLE
order columns in BFS output

### DIFF
--- a/src/main/scala/org/graphframes/lib/BFS.scala
+++ b/src/main/scala/org/graphframes/lib/BFS.scala
@@ -192,7 +192,17 @@ private object BFS extends Logging with Serializable {
     }
     if (foundPath) {
       logInfo(s"GraphFrame.bfs found path of length $iter.")
-      paths
+      def rank(c: String): Double = {
+        // from < e0 < v1 < e1 < ... < to
+        c match {
+          case "from" => 0.0
+          case "to" => Double.PositiveInfinity
+          case _ if c.startsWith("e") => 0.6 + c.substring(1).toInt
+          case _ if c.startsWith("v") => 0.3 + c.substring(1).toInt
+        }
+      }
+      val ordered = paths.columns.sortBy(rank _)
+      paths.select(ordered.map(col): _*)
     } else {
       logInfo(s"GraphFrame.bfs failed to find a path of length <= $maxPathLength.")
       // Return empty DataFrame

--- a/src/test/scala/org/graphframes/lib/BFSSuite.scala
+++ b/src/test/scala/org/graphframes/lib/BFSSuite.scala
@@ -97,7 +97,7 @@ class BFSSuite extends SparkFunSuite with GraphFrameTestSparkContext {
   test("0 hops, aka from=to") {
     val paths = g.bfs(col("id") === "a", col("id") === "a").run()
     assert(paths.count() === 1)
-    assert(paths.columns.toSet === Set("from", "to"))
+    assert(paths.columns === Seq("from", "to"))
     assert(paths.select("from.id").head().getString(0) === "a")
     assert(paths.select("to.id").head().getString(0) === "a")
   }
@@ -105,14 +105,14 @@ class BFSSuite extends SparkFunSuite with GraphFrameTestSparkContext {
   test("1 hop, aka single edge paths") {
     val paths = g.bfs(col("id") === "a", col("id") === "b").run()
     assert(paths.count() === 1)
-    assert(paths.columns.toSet === Set("from", "e0", "to"))
+    assert(paths.columns === Seq("from", "e0", "to"))
     assert(paths.select("from.id", "to.id").head() === Row("a", "b"))
   }
 
   test("ties") {
     val paths = g.bfs(col("id") === "e", col("id") === "b").run()
     assert(paths.count() === 2)
-    assert(paths.columns.toSet === Set("from", "e0", "v1", "e1", "v2", "e2", "to"))
+    assert(paths.columns === Seq("from", "e0", "v1", "e1", "v2", "e2", "to"))
     paths.select("to.id").collect().foreach { case Row(id: String) =>
       assert(id === "b")
     }


### PR DESCRIPTION
Ordered columns makes the resulting table easier to inspect.