### PR TITLE
update shortest path test to make it fail on spark 1.5 and 1.6

### DIFF
--- a/src/main/spark-1.4/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-1.4/org/apache/spark/sql/SQLHelpers.scala
@@ -28,7 +28,7 @@ object SQLHelpers {
 
   /**
    * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020.
+   * This is a workaround for SPARK-9020 and SPARK-13473.
    */
   def zipWithUniqueId(df: DataFrame): DataFrame = {
     val sqlContext = df.sqlContext

--- a/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
@@ -48,10 +48,10 @@ class ShortestPathsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   test("friends graph") {
     val friends = examples.Graphs.friends
-    val g = friends.shortestPaths.landmarks(Seq("a")).run()
-    val expected = Set[(String, Map[String, Int])](("a", Map("a" -> 0)), ("b", Map.empty),
-      ("c", Map.empty), ("d", Map("a" -> 1)), ("e", Map("a" -> 2)), ("f", Map.empty),
-      ("g", Map.empty))
+    val g = friends.shortestPaths.landmarks(Seq("a", "d")).run()
+    val expected = Set[(String, Map[String, Int])](("a", Map("a" -> 0, "d" -> 2)), ("b", Map.empty),
+      ("c", Map.empty), ("d", Map("a" -> 1, "d" -> 0)), ("e", Map("a" -> 2, "d" -> 1)),
+      ("f", Map.empty), ("g", Map.empty))
     val results = g.vertices.select("id", "distances").collect().map {
       case Row(id: String, spMap: Map[String, Int] @unchecked) =>
         (id, spMap)


### PR DESCRIPTION
This could be a bug in our integral ID mapping.

I can reproduce the bug in Spark 1.6:

~~~scala
val df = sqlContext.range(10).select(col("id"), monotonicallyIncreasingId().as("long_id”))
df.show()

+---+-----------+
| id|    long_id|
+---+-----------+
|  0|          0|
|  1|          1|
|  2| 8589934592|
|  3| 8589934593|
|  4| 8589934594|
|  5|17179869184|
|  6|17179869185|
|  7|25769803776|
|  8|25769803777|
|  9|25769803778|
+---+-----------+

df.filter(col("id") === 3).show()

+---+----------+
| id|   long_id|
+---+----------+
|  3|8589934592|
+---+----------+
~~~

If seems that `filter` is pushed down below `monotonicallyIncreadingId`, which is wrong. 

~~~
== Physical Plan ==
Project [id#837L,monotonicallyincreasingid() AS long_id#838L]
+- Filter (id#837L = 3)
   +- Scan ExistingRDD[id#837L]
~~~

@rxin 