### PR TITLE
simplify triangle counts

### DIFF
--- a/src/main/scala/org/graphframes/lib/TriangleCount.scala
+++ b/src/main/scala/org/graphframes/lib/TriangleCount.scala
@@ -17,7 +17,7 @@
 
 package org.graphframes.lib
 
-import org.apache.spark.sql.functions.{col, when}
+import org.apache.spark.sql.functions.{array, col, explode, when}
 
 import org.graphframes.GraphFrame
 import org.graphframes.GraphFrame.{DST, ID, LONG_DST, LONG_SRC, SRC}
@@ -47,32 +47,23 @@ private object TriangleCount {
   private def run(graph: GraphFrame): GraphFrame = {
     // Dedup edges by flipping them to have LONG_SRC < LONG_DST
     // TODO (when we drop support for Spark 1.4): Use functions greatest, smallest instead of UDFs
-    val dedupedE = graph.indexedEdges.selectExpr(SRC, DST,
-      s"if($LONG_SRC < $LONG_DST, $LONG_SRC, $LONG_DST) as $LONG_SRC",
-      s"if($LONG_SRC < $LONG_DST, $LONG_DST, $LONG_SRC) as $LONG_DST")
-      .dropDuplicates(Seq(LONG_SRC, LONG_DST))
-      .select(SRC, DST)
+    val dedupedE = graph.indexedEdges
+      .filter(s"$LONG_SRC != $LONG_DST")
+      .selectExpr(
+        s"if($LONG_SRC < $LONG_DST, $SRC, $DST) as $SRC",
+        s"if($LONG_SRC < $LONG_DST, $DST, $SRC) as $DST")
+      .dropDuplicates(Seq(SRC, DST))
     val g2 = GraphFrame(graph.vertices, dedupedE)
 
-    // 2 types of triangles:
-    // - cycles: edges forming a cycle.  These are counted 3 times each by motif finding.
-    // - noncycles: cycle with one edge flipped.  These are counted 1 time each by motif finding.
-    val cycles = g2.find("(a)-[]->(b); (b)-[]->(c); (c)-[]->(a)")
-      .select(col("a.id").as("a"), col("b.id").as("b"), col("c.id").as("c"))
-      .filter("a != b AND b != c AND c != a")
-    val noncycles = g2.find("(a)-[]->(b); (b)-[]->(c); (a)-[]->(c)")
-      .select(col("a.id").as("a"), col("b.id").as("b"), col("c.id").as("c"))
-      .filter("a != b AND b != c AND c != a")
+    // Because SRC < DST, there exists only one type of triangles:
+    // - Non-cycle with one edge flipped.  These are counted 1 time each by motif finding.
+    val triangles = g2.find("(a)-[]->(b); (b)-[]->(c); (a)-[]->(c)")
 
-    // TODO: Can we make this more efficient using lateral view explode?
-    // Count the triangle for each vertex.
-    // - Since cycles are counted 3x, we can just keep "a"
-    // - Since noncycles are counted once, we need to count each of a,b,c
-    val allTriangles = noncycles.select(col("a").as(ID))
-      .unionAll(noncycles.select(col("b").as(ID)))
-      .unionAll(noncycles.select(col("c").as(ID)))
-      .unionAll(cycles.select(col("a").as(ID)))
-    val triangleCounts = allTriangles.groupBy(ID).count()
+    val triangleCounts = triangles
+      .select(explode(array(col("a.id"), col("b.id"), col("c.id"))).as(ID))
+      .groupBy(ID)
+      .count()
+
     val v = graph.vertices
     val countsCol = when(col("count").isNull, 0L).otherwise(col("count"))
     val newV = v.join(triangleCounts, v(ID) === triangleCounts(ID), "left_outer")


### PR DESCRIPTION
If we flip the edge directions such that src < dst, the pattern `(a)-[]->(b); (b)-[]->(c); (a)-[]->(c)` would uniquely match triangles. It helps simplify the implementation. Tests are not changed in this PR.

@thunterdb 