### PR TITLE
Sort DataFrame columns from motif finding

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -363,8 +363,14 @@ class GraphFrame private(
    *
    * @param prevPatterns  Patterns already handled
    * @param prevDF  Current DataFrame based on prevPatterns
+   * @param prevNames Current sequence of column names in the order as specified by prevPatterns
+   *                  For instance, `"(a)-[e]->(b)"` is Seq("a", "e", "b")
+   *                  `"(a)-[e]->(b); (b)-[]->(c)"` is Seq("a", "e", "b", "c")
    * @param remainingPatterns  Patterns not yet handled
-   * @return  `DataFrame` augmented with the next pattern, or the previous DataFrame if done
+   * @return Tuple2[`DataFrame`, Seq[String]] `DataFrame` augmented with the next pattern,
+   *                                          or the previous DataFrame if done
+   *                                          Seq[String] sequence of column names for the `DataFrame`
+   *                                          appended to in order as specified by the next pattern
    */
   private def findSimple(
       prevPatterns: Seq[Pattern],

--- a/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -103,6 +103,21 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(edges.collect().toSet === Set(Row(2L, 3L)))
   }
 
+  test("find column order") {
+    val fof = g.find("(u)-[e]->(v); (v)-[]->(w); !(u)-[]->(w); !(w)-[]->(u)")
+    assert(fof.columns === Array("u", "e", "v", "w"))
+    assert(fof.select("u.id", "v.id", "w.id").collect().toSet === Set(Row(1L, 2L, 3L)))
+
+    val fv = g.find("(u)")
+    assert(fv.columns === Array("u"))
+
+    val fve = g.find("(u)-[e2]->()")
+    assert(fve.columns === Array("u", "e2"))
+
+    val fed = g.find("()-[e]->(w)")
+    assert(fed.columns === Array("e", "w"))
+  }
+
   test("stateful predicates via UDFs") {
     val chain4 = g.find("(a)-[ab]->(b); (b)-[bc]->(c); (c)-[cd]->(d)")
 


### PR DESCRIPTION
Had another attempt to reparse pattern for name, but with the need to deduplicate for pattern like `(a)-[]->(b); (b)-[]->(c); (c)-[]->(a)` which is already implemented in `seen()` thought it might be better to have a single pass at the cost of slightly less readable code with pair as return values.

Thought? #45