### PR TITLE
Add cache(), persist() methods

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -16,8 +16,8 @@
 #
 
 from pyspark import SparkContext
-from pyspark.storagelevel import StorageLevel
 from pyspark.sql import DataFrame, SQLContext
+from pyspark.storagelevel import StorageLevel
 
 def _from_java_gf(jgf, sqlContext):
     """

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -16,6 +16,7 @@
 #
 
 from pyspark import SparkContext
+from pyspark.storagelevel import StorageLevel
 from pyspark.sql import DataFrame, SQLContext
 
 def _from_java_gf(jgf, sqlContext):
@@ -95,6 +96,28 @@ class GraphFrame(object):
 
     def __repr__(self):
         return self._jvm_graph.toString()
+
+    def cache(self):
+        """ Persist the dataframe representation of vertices and edges of the graph with the default
+        storage level.
+        """
+        self._jvm_graph.cache()
+        return self
+
+    def persist(self, storageLevel=StorageLevel.MEMORY_ONLY):
+        """Persist the dataframe representation of vertices and edges of the graph with the given
+        storage level.
+        """
+        javaStorageLevel = self._sc._getJavaStorageLevel(storageLevel)
+        self._jvm_graph.persist(javaStorageLevel)
+        return self
+
+    def unpersist(self, blocking=True):
+        """Mark the dataframe representation of vertices and edges of the graph as non-persistent,
+        and remove all blocks for it from memory and disk.
+        """
+        self._jvm_graph.unpersist(blocking)
+        return self
 
     @property
     def outDegrees(self):

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -112,7 +112,7 @@ class GraphFrame(object):
         self._jvm_graph.persist(javaStorageLevel)
         return self
 
-    def unpersist(self, blocking=True):
+    def unpersist(self, blocking=False):
         """Mark the dataframe representation of vertices and edges of the graph as non-persistent,
         and remove all blocks for it from memory and disk.
         """

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -67,6 +67,11 @@ class GraphFrameTest(GraphFrameTestCase):
                             g.triplets.sort("src.id").select("src", "dst", "edge").take(1))
         assert tripletsFirst == [("A", "B", "love")]
 
+    def test_cache(self):
+        g = self.g
+        g.cache()
+        g.unpersist()
+
     def test_degrees(self):
         g = self.g
         outDeg = g.outDegrees

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -60,6 +60,57 @@ class GraphFrame private(
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
 
+  /**
+   * Persist the dataframe representation of vertices and edges of the graph with the default
+   * storage level.
+   */
+  def cache(): this.type = {
+    persist()
+  }
+
+  /**
+   * Persist the dataframe representation of vertices and edges of the graph with the default
+   * storage level.
+   */
+  def persist(): this.type = {
+    vertices.persist()
+    edges.persist()
+    this
+  }
+
+  /**
+   * Persist the dataframe representation of vertices and edges of the graph with the given
+   * storage level.
+   * @param newLevel  One of: `MEMORY_ONLY`, `MEMORY_AND_DISK`, `MEMORY_ONLY_SER`,
+   * `MEMORY_AND_DISK_SER`, `DISK_ONLY`, `MEMORY_ONLY_2`, `MEMORY_AND_DISK_2`, etc..
+   */
+  def persist(newLevel: StorageLevel): this.type = {
+    vertices.persist(newLevel)
+    edges.persist(newLevel)
+    this
+  }
+
+  /**
+   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
+   * remove all blocks for it from memory and disk.
+   */
+  def unpersist(): this.type = {
+    vertices.unpersist()
+    edges.unpersist()
+    this
+  }
+
+  /**
+   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
+   * remove all blocks for it from memory and disk.
+   * @param blocking  Whether to block until all blocks are deleted.
+   */
+  def unpersist(blocking: Boolean): this.type = {
+    vertices.unpersist(blocking)
+    edges.unpersist(blocking)
+    this
+  }
+
   // ============== Basic structural methods ============
 
   /**

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -232,5 +232,6 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     g.unpersist()
     // org.apache.spark.sql.execution.columnar.InMemoryRelation is private and not accessible
+    // This has prevented us from validating DataFrame's are cached.
   }
 }

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path
 
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -222,5 +223,14 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       (id, deg)
     }.toMap
     assert(degrees === Map(1L -> 2, 2L -> 3, 3L -> 1))
+  }
+
+  test("cache") {
+    val g = GraphFrame(vertices, edges)
+
+    g.persist(StorageLevel.MEMORY_ONLY)
+
+    g.unpersist()
+    // org.apache.spark.sql.execution.columnar.InMemoryRelation is private and not accessible
   }
 }


### PR DESCRIPTION
See #64
Add API in Scala and Python

I couldn't find a way to test this - checks for queryExecution can't access some internal field which is needed to check if the operation is cached.
