### PR TITLE
Updated link to graphframes package. Now it points to graphframes pac…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Refer to the [User Guide](user-guide.html) for a full list of queries and algori
 
 # Downloading
 
-Get GraphFrames from the [Spark Packages website](http://spark-packages.org).
+Get GraphFrames from the [Spark Packages website](http://spark-packages.org/package/graphframes/graphframes).
 This documentation is for GraphFrames version {{site.GRAPHFRAMES_VERSION}}.
 GraphFrames depends on Apache Spark, which is available for download from the
 [Apache Spark website](http://spark.apache.org).


### PR DESCRIPTION
…kage and not the homepage of spark package website. Fixes #83