### PR TITLE
[95] Official release numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-all: 1.4.1 1.5.2 1.6.2 2.0.0
+all: 2.0.0s2.10
+#1.4.1 1.5.2 1.6.2 2.0.0
 
 clean:
 	rm -rf target/graphframes_*.zip
 
 1.4.1 1.5.2 1.6.2 2.0.0:
 	build/sbt -Dspark.version=$@ spDist
+
+2.0.0s2.10:
+	build/sbt -Dspark.version=2.0.0 -Dscala.version=2.10.4 spDist assembly test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-all: 2.0.0s2.10
-#1.4.1 1.5.2 1.6.2 2.0.0
+all: 2.0.0s2.10 1.4.1 1.5.2 1.6.2 2.0.0
 
 clean:
 	rm -rf target/graphframes_*.zip

--- a/build.sbt
+++ b/build.sbt
@@ -23,11 +23,12 @@ scalaVersion := scalaVer
 spName := "graphframes/graphframes"
 
 // Don't forget to set the version
-version := s"0.2.0-spark$sparkBranch-SNAPSHOT"
+version := s"0.2.0-spark$sparkBranch"
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
 
+spAppendScalaVersion := true
 
 // Add Spark components this package depends on, e.g, "mllib", ....
 sparkComponents ++= Seq("graphx", "sql")

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,8 @@ val defaultScalaVer = sparkBranch match {
 }
 val scalaVer = sys.props.getOrElse("scala.version", defaultScalaVer)
 val defaultScalaTestVer = scalaVer match {
-  case "2.10.4" => "2.0"
-  case "2.10.5" => "2.0"
-  case "2.11.7" => "2.2.6" // scalatest_2.11 does not have 2.0 published
+  case s if s.startsWith("2.10") => "2.0"
+  case s if s.startsWith("2.11") => "2.2.6" // scalatest_2.11 does not have 2.0 published
 }
 
 sparkVersion := sparkVer


### PR DESCRIPTION
This makes the full release of graphframes 0.2.0 with the following versions:
 - spark 1.[4,5,6] + scala 2.10
 - spark 2.0 + scala 2.[10,11]

The only shaky part is the lack of testing of spark 2.0 + scala 2.10 (only done for scala tests, not python tests, during the release process).