### PR TITLE
New connected components implementation

### DIFF
--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -200,7 +200,14 @@ private object ConnectedComponents extends Logging {
     hashJoined.union(broadcastJoined)
   }
 
-  def run(graph: GraphFrame, broadcastThreshold: Int): DataFrame = {
+  /**
+   * Runs connected components with default parameters.
+   */
+  def run(graph: GraphFrame): DataFrame = {
+    new ConnectedComponents(graph).run()
+  }
+
+  private def run(graph: GraphFrame, broadcastThreshold: Int): DataFrame = {
     val runId = UUID.randomUUID().toString.takeRight(8)
     val logPrefix = s"[CC $runId]"
     logger.info(s"$logPrefix Start connected components with run ID $runId.")

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{Column, DataFrame, Row}
+import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.storage.StorageLevel
 
 import org.graphframes.{GraphFrame, Logging}
@@ -158,12 +158,12 @@ private object ConnectedComponents extends Logging {
       minNbrs: DataFrame,
       broadcastThreshold: Int,
       logPrefix: String): DataFrame = {
+    import edges.sqlContext.implicits._
     val hubs = minNbrs.filter(col(CNT) > broadcastThreshold)
       .select(SRC, MIN_NBR)
+      .as[(Long, Long)]
       .collect()
-      .map { case Row(src: Long, minNbr: Long) =>
-        src -> minNbr
-      }.toMap // TODO: use OpenHashMap
+      .toMap // TODO: use OpenHashMap
     if (hubs.isEmpty) {
       return edges.join(minNbrs, SRC)
     } else {

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -17,10 +17,17 @@
 
 package org.graphframes.lib
 
-import org.apache.spark.graphx.{lib => graphxlib}
-import org.apache.spark.sql.DataFrame
+import java.io.IOException
+import java.util.UUID
 
-import org.graphframes.GraphFrame
+import scala.collection.mutable
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.storage.StorageLevel
+
+import org.graphframes.{GraphFrame, Logging}
 
 /**
  * Connected components algorithm.
@@ -28,27 +35,255 @@ import org.graphframes.GraphFrame
  * Computes the connected component membership of each vertex and returns a DataFrame of vertex
  * information with each vertex assigned a component ID.
  *
+ * The computation is done using alternating large star and small star iterations proposed in
+ * "Connected Components in MapReduce and Beyond" with skewed join optimization.
+ *
  * The resulting DataFrame contains all the vertex information and one additional column:
  *  - component (`LongType`): unique ID for this component
  *
  * The resulting edges DataFrame is the same as the original edges DataFrame.
+ *
+ * @see https://mmds-data.org/presentations/2014/vassilvitskii_mmds14.pdf
  */
-class ConnectedComponents private[graphframes] (private val graph: GraphFrame) extends Arguments {
+class ConnectedComponents private[graphframes] (
+    private val graph: GraphFrame) extends Arguments with Logging {
+
+  private var broadcastThreshold: Int = 1000000
+
+  /**
+    * Sets broadcast threshold in propagating component assignments (default: 1000000).
+    * If a node degree is greater than this threshold at some iteration, its component assignment
+    * will be collected and then broadcasted back to propagate the assignment to its neighbors.
+    * Otherwise, the assignment propagation is done by a normal Spark join.
+   */
+  def setBroadcastThreshold(value: Int): this.type = {
+    broadcastThreshold = value
+    this
+  }
+
+  /**
+    * Gets broadcast threshold in propagating component assignment.
+    *
+    * @see [[setBroadcastThreshold()]]
+    */
+  def getBroadcastThreshold: Long = broadcastThreshold
+
+  // TODO: allow different checkpoint interval
+
+  private var checkpointInterval: Int = 1
+
+  /**
+    * Sets checkpoint interval in terms of number of iterations (default: 1).
+    * Checkpointing regularly helps recover from failures, clean shuffle files, and shorten the
+    * lineage of the computation graph.
+    * Checkpoint data is saved under [[org.apache.spark.SparkContext.getCheckpointDir]] with
+    * prefix "connected-components".
+    * Throws a [[java.io.IOException]] if the checkpoint directory is not set.
+    * Set the value to -1 to disable checkpointing (not recommended for large graphs).
+    */
+  def setCheckpointInterval(value: Int): this.type = {
+    assert(value == 1, "Only checkpointInterval=1 is supported right now.")
+    checkpointInterval = value
+    this
+  }
+
+  def getCheckpointInterval: Int = checkpointInterval
+
 
   /**
    * Runs the algorithm.
    */
   def run(): DataFrame = {
-    ConnectedComponents.run(graph)
+    ConnectedComponents.run(
+      graph,
+      broadcastThreshold = broadcastThreshold)
   }
 }
 
-private object ConnectedComponents {
+private object ConnectedComponents extends Logging {
 
-  def run(graph: GraphFrame): DataFrame = {
-    val gx = graphxlib.ConnectedComponents.run(graph.cachedTopologyGraphX)
-    GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(COMPONENT_ID)).vertices
+  import org.graphframes.GraphFrame._
+
+  private val COMPONENT = "component"
+  private val ORIG_ID = "orig_id"
+  private val MIN_NBR = "min_nbr"
+  private val CNT = "cnt"
+  private val CHECKPOINT_NAME_PREFIX = "connected-components"
+
+  /**
+   * Returns the symmetric directed graph of the graph specified by input edges.
+   * @param ee non-bidirectional edges
+   */
+  private def symmetrize(ee: DataFrame): DataFrame = {
+    val EDGE = "_edge"
+    ee.select(explode(array(struct(SRC, DST), struct(col(DST).as(SRC), col(SRC).as(DST)))).as(EDGE))
+      .select(col(s"$EDGE.$SRC").as(SRC), col(s"$EDGE.$DST").as(DST))
   }
 
-  private val COMPONENT_ID = "component"
+  /**
+   * Prepares the input graph for computing connected components by:
+   *   - de-duplicating vertices and assigning unique long IDs to each,
+   *   - changing edge directions to have increasing long IDs from src to dst,
+   *   - de-duplicating edges and removing loops.
+   * In the returned GraphFrame, the vertex DataFrame has two columns:
+   *   - column `id` stores a long ID assigned to the vertex,
+   *   - column `orig_id` stores the original ID.
+   * The edge DataFrame has two columns:
+   *   - column `src` stores the long ID of the source vertex,
+   *   - column `dst` stores the long ID of the destination vertex,
+   * where we always have `src` < `dst`.
+   * The returned graph is persisted in memory and disk.
+   */
+  private def prepare(graph: GraphFrame): GraphFrame = {
+    // TODO: This assignment job might fail if the graph is skewed.
+    val vertices = graph.indexedVertices
+      .select(col(LONG_ID).as(ID), col(ID).as(ORIG_ID))
+      .distinct()
+    val edges = graph.indexedEdges
+      .select(col(LONG_SRC).as(SRC), col(LONG_DST).as(DST))
+    val orderedEdges = edges.filter(col(SRC) =!= col(DST))
+      .select(minValue(col(SRC), col(DST)).as(SRC), maxValue(col(SRC), col(DST)).as(DST))
+      .distinct()
+    GraphFrame(vertices, orderedEdges)
+      .persist(StorageLevel.MEMORY_AND_DISK)
+  }
+
+  /**
+   * Returns the min neighbors of each vertex in a DataFrame with three columns:
+   *   - `src`, the ID of the vertex
+   *   - `min_nbr`, the min ID of its neighbors
+   *   - `cnt`, the total number of neighbors
+   * @return a DataFrame with three columns
+   */
+  private def minNbrs(ee: DataFrame): DataFrame = {
+    symmetrize(ee).groupBy(SRC).agg(min(col(DST)).as(MIN_NBR), count("*").as(CNT))
+  }
+
+  private def minValue(x: Column, y: Column): Column = {
+    when(x < y, x).otherwise(y)
+  }
+
+  private def maxValue(x: Column, y: Column): Column = {
+    when(x > y, x).otherwise(y)
+  }
+
+  /**
+   * Performs a possibly skewed join between edges and current component assignments.
+   * The skew join is done by broadcast join for frequent keys and normal join for the rest.
+   */
+  private def skewedJoin(
+      edges: DataFrame,
+      minNbrs: DataFrame,
+      broadcastThreshold: Int,
+      logPrefix: String): DataFrame = {
+    import edges.sqlContext.implicits._
+    val hubs = minNbrs.filter(col(CNT) > broadcastThreshold)
+      .select(SRC, MIN_NBR)
+      .as[(Long, Long)]
+      .collect()
+      .toMap // TODO: use OpenHashMap
+    if (hubs.isEmpty) {
+      return edges.join(minNbrs, SRC)
+    } else {
+      logger.debug(s"$logPrefix Number of skewed keys: ${hubs.size}.")
+    }
+    val isHub = udf { id: Long =>
+      hubs.contains(id)
+    }
+    val minNbr = udf { id: Long =>
+      hubs(id)
+    }
+    val hashJoined = edges.filter(!isHub(col(SRC)))
+      .join(minNbrs.filter(!isHub(col(SRC))), SRC)
+      .select(SRC, DST, MIN_NBR)
+    val broadcastJoined = edges.filter(isHub(col(SRC)))
+      .select(col(SRC), col(DST), minNbr(col(SRC)))
+    hashJoined.union(broadcastJoined)
+  }
+
+  def run(graph: GraphFrame, broadcastThreshold: Int): DataFrame = {
+    val runId = UUID.randomUUID().toString.takeRight(8)
+    val logPrefix = s"[CC $runId]"
+    logger.info(s"$logPrefix Start connected components with run ID $runId.")
+
+    val sqlContext = graph.sqlContext
+    val sc = sqlContext.sparkContext
+    import sqlContext.implicits._
+
+    val checkpointDir = sc.getCheckpointDir.map { dir =>
+      new Path(dir, s"$CHECKPOINT_NAME_PREFIX-$runId").toString
+    }.getOrElse {
+      throw new IOException(
+        "Checkpoint directory is not set. Please set it first using sc.setCheckpointDir")
+    }
+    logger.info(s"$logPrefix Use $checkpointDir for checkpointing.")
+
+    logger.info(s"$logPrefix Preparing the graph for connected component computation ...")
+    val g = prepare(graph)
+    val vv = g.vertices
+    var ee = g.edges
+    val numVertices = vv.count()
+    val numEdges = ee.count()
+    logger.info(s"$logPrefix Found $numVertices vertices and $numEdges after preparation.")
+
+    var converged = false
+    var k = 0
+    var prevSum = Long.MaxValue
+    while (!converged) {
+      val toBeCleaned = mutable.ArrayBuffer.empty[DataFrame]
+      toBeCleaned += ee
+      // compute min neighbors including self
+      val minNbrs1 = minNbrs(ee)
+        .withColumn(MIN_NBR, minValue(col(SRC), col(MIN_NBR)).as(MIN_NBR))
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      toBeCleaned += minNbrs1
+      // connect all strictly larger neighbors to the min neighbor (including self)
+      ee = skewedJoin(ee, minNbrs1, broadcastThreshold, logPrefix)
+        .select(col(DST).as(SRC), col(MIN_NBR).as(DST)) // src > dst
+        .distinct()
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      toBeCleaned += ee
+      // compute min neighbors
+      val minNbrs2 = minNbrs(ee)
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      toBeCleaned += minNbrs2
+      // connect all smaller neighbors to the min neighbor
+      ee = skewedJoin(ee, minNbrs2, broadcastThreshold, logPrefix)
+        .select(col(MIN_NBR).as(SRC), col(DST)) // src <= dst
+      // connect self to the min neighbor
+      ee = ee
+        .union(
+          minNbrs2.select( // src <= dst
+            minValue(col(SRC), col(MIN_NBR)).as(SRC),
+            maxValue(col(SRC), col(MIN_NBR)).as(DST)))
+        .filter(col(SRC) =!= col(DST)) // src < dst
+        .distinct()
+      // TODO: remove this after DataFrame.checkpoint is implemented
+      val out = s"$checkpointDir/$k"
+      ee.write.parquet(out)
+      if (k > 1) {
+        FileSystem.get(sc.hadoopConfiguration)
+          .delete(new Path(s"$checkpointDir/${k - 1}"), true)
+      }
+      toBeCleaned.foreach(df => df.unpersist(true))
+      System.gc() // hint Spark to clean shuffle directories
+      // may hit S3 eventually consistent issue
+      ee = sqlContext.read.parquet(out)
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      val currSum = ee.select(sum(col(SRC))).as[Long].first()
+      logInfo(s"$logPrefix Sum of assigned components in iteration $k: $currSum.")
+      if (currSum == prevSum) {
+        converged = true
+      } else {
+        prevSum = currSum
+      }
+      k += 1
+    }
+
+    logger.info(s"$logPrefix Connected components converged in $k iterations.")
+
+    logger.info(s"$logPrefix Join and return component assignments with original vertex IDs.")
+    vv.join(ee, vv(ID) === ee(DST), "left_outer")
+      .select(vv(ORIG_ID).as(ID), when(ee(SRC).isNull, vv(ID)).otherwise(ee(SRC)).as(COMPONENT))
+  }
 }

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -68,35 +68,11 @@ class ConnectedComponents private[graphframes] (
     */
   def getBroadcastThreshold: Long = broadcastThreshold
 
-  // TODO: allow different checkpoint interval
-
-  private var checkpointInterval: Int = 1
-
-  /**
-    * Sets checkpoint interval in terms of number of iterations (default: 1).
-    * Checkpointing regularly helps recover from failures, clean shuffle files, and shorten the
-    * lineage of the computation graph.
-    * Checkpoint data is saved under [[org.apache.spark.SparkContext.getCheckpointDir]] with
-    * prefix "connected-components".
-    * Throws a [[java.io.IOException]] if the checkpoint directory is not set.
-    * Set the value to -1 to disable checkpointing (not recommended for large graphs).
-    */
-  def setCheckpointInterval(value: Int): this.type = {
-    assert(value == 1, "Only checkpointInterval=1 is supported right now.")
-    checkpointInterval = value
-    this
-  }
-
-  def getCheckpointInterval: Int = checkpointInterval
-
-
   /**
    * Runs the algorithm.
    */
   def run(): DataFrame = {
-    ConnectedComponents.run(
-      graph,
-      broadcastThreshold = broadcastThreshold)
+    ConnectedComponents.run(graph, broadcastThreshold = broadcastThreshold)
   }
 }
 

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -31,7 +31,7 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     val e = sqlContext.createDataFrame(List((0L, 0L, 1L))).toDF("src", "dst", "test")
       .filter("src > 10")
     val g = GraphFrame(v, e)
-    val comps = ConnectedComponents.run(g)
+    val comps = g.connectedComponents.run()
     TestUtils.testSchemaInvariants(g, comps)
     TestUtils.checkColumnType(comps.schema, "component", DataTypes.LongType)
     assert(comps.count() === 1)

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -18,6 +18,7 @@
 package org.graphframes.lib
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.DataTypes
 
 import org.graphframes._
@@ -55,6 +56,8 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
 
   test("friends graph") {
     val friends = examples.Graphs.friends
-    friends.connectedComponents.run()
+    val components = friends.connectedComponents.run()
+    val numComponents = components.select(countDistinct("components")).head().getLong(0)
+    assert(numComponents === 2)
   }
 }


### PR DESCRIPTION
This PR replaces the GraphX implementation of connected components by a DataFrame-based implementation. It also switched the algorithm to the one proposed in "Connected Components in MapReduce and Beyond". The new implementation handles skewness by separating the joins into broadcast join of vertices of high degrees and normal join of the rest.

The implementation was tested on a graph w/ ~2 billion edges, but without long ID conversion.

Note that it uses `indexedVertices` and `indexedEdges` to assign long IDs. This might have performance issues if the input graph is skewed. We can do a follow-up PR to address it.

The unit tests are updated to check the broadcast join path. The coverage is apparently not ideal at this time.

cc: @jkbradley 