### PR TITLE
[#124] Support checkpoint interval in connected components

### DIFF
--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -92,7 +92,7 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     // Checks whether the input DataFrame is from some checkpoint data.
     // TODO: The implemetnation is a little hacky.
     def isFromCheckpoint(df: DataFrame): Boolean = {
-      df.queryExecution.logical.toString().contains("parquet")
+      df.queryExecution.logical.toString().toLowerCase.contains("parquet")
     }
 
     val components0 = cc.setCheckpointInterval(0).run()


### PR DESCRIPTION
This PR adds `checkpointInterval` to the new CC implementation. The logic for removing out-of-scope persisted DataFrames was removed to simplify the code. Those should be cleaned by Spark automatically. `System.gc()` gives hint.

The default value is 1 to avoid exploding the query plan. This might change after we support query plan checkpointing in Spark SQL.

cc: @jkbradley 