### PR TITLE
add empty and chain graphs to Graphs

### DIFF
--- a/src/main/scala/org/graphframes/examples/Graphs.scala
+++ b/src/main/scala/org/graphframes/examples/Graphs.scala
@@ -17,17 +17,43 @@
 
 package org.graphframes.examples
 
+import scala.reflect.runtime.universe.TypeTag
+
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.functions.{col, randn, udf}
 
 import org.graphframes.GraphFrame
+import org.graphframes.GraphFrame._
 
 class Graphs private[graphframes] () {
   // Note: these cannot be values: we are creating and destroying spark contexts during the tests,
   // and turning these into vals means we would hold onto a potentially destroyed spark context.
   private def sc: SparkContext = SparkContext.getOrCreate()
   private def sqlContext: SQLContext = SQLContext.getOrCreate(sc)
+
+  /**
+   * Returns an empty GraphFrame of the given ID type.
+   */
+  def empty[T: TypeTag]: GraphFrame = {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+    val vertices = Seq.empty[Tuple1[T]].toDF(ID)
+    val edges = Seq.empty[(T, T)].toDF(SRC, DST)
+    GraphFrame(vertices, edges)
+  }
+
+  /**
+   * Returns a chain graph of the given size with Long ID type.
+   * The vertex IDs are 0, 1, ..., size-1, and the edges are (0, 1), (1, 2), ....
+   */
+  def chain(size: Long): GraphFrame = {
+    require(size >= 0, s"Chain graph size must be nonnegative but got $size.")
+    val vertices = sqlContext.range(size).toDF(ID)
+    val edges = sqlContext.range(size - 1L).toDF(ID)
+      .select(col(ID).as(SRC), (col(ID) + 1L).as(DST))
+    GraphFrame(vertices, edges)
+  }
 
   /**
    * Graph of friends in a social network.

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -30,6 +30,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{IntegerType, StringType}
 import org.apache.spark.sql.{DataFrame, Row}
 
+import org.graphframes.examples.Graphs
+
 
 class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
@@ -233,5 +235,14 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     g.unpersist()
     // org.apache.spark.sql.execution.columnar.InMemoryRelation is private and not accessible
     // This has prevented us from validating DataFrame's are cached.
+  }
+
+  test("basic operations on an empty graph") {
+    for (empty <- Seq(Graphs.empty[Int], Graphs.empty[Long], Graphs.empty[String])) {
+      assert(empty.inDegrees.count() === 0L)
+      assert(empty.outDegrees.count() === 0L)
+      assert(empty.degrees.count() === 0L)
+      assert(empty.triplets.count() === 0L)
+    }
   }
 }

--- a/src/test/scala/org/graphframes/examples/GraphsSuite.scala
+++ b/src/test/scala/org/graphframes/examples/GraphsSuite.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graphframes.examples
+
+import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite}
+
+
+class GraphsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
+
+  test("empty graph") {
+    for (empty <- Seq(Graphs.empty[Int], Graphs.empty[Long], Graphs.empty[String])) {
+      assert(empty.vertices.count() === 0L)
+      assert(empty.edges.count() === 0L)
+    }
+  }
+
+  test("chain graph") {
+    val sqlContext = this.sqlContext
+    import sqlContext.implicits._
+
+    val chain0 = Graphs.chain(0L)
+    assert(chain0.vertices.count() === 0L)
+    assert(chain0.edges.count() === 0L)
+
+    val chain1 = Graphs.chain(1L)
+    assert(chain1.vertices.as[Long].collect() === Array(0L))
+    assert(chain1.edges.count() === 0L)
+
+    val chain2 = Graphs.chain(2L)
+    assert(chain2.vertices.as[Long].collect().toSet === Set(0L, 1L))
+    assert(chain2.edges.as[(Long, Long)].collect() === Array((0L, 1L)))
+
+    val chain3 = Graphs.chain(3L)
+    assert(chain3.vertices.as[Long].collect().toSet === Set(0L, 1L, 2L))
+    assert(chain3.edges.as[(Long, Long)].collect().toSet === Set((0L, 1L), (1L, 2L)))
+
+    withClue("Constructing a large chain graph shouldn't OOM the driver.") {
+      Graphs.chain(1e10.toLong)
+    }
+  }
+}


### PR DESCRIPTION
This PR adds two simple graphs to `examples.Graphs`:

* empty graph with arbitrary ID type (that can be recognized by SQL)
* chain graph

The purpose is to simplify unit tests coming in #121.