### PR TITLE
use DecimalType for the sum in connected components

### DIFF
--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -18,10 +18,12 @@
 package org.graphframes.lib
 
 import java.io.IOException
+import java.math.BigDecimal
 import java.util.UUID
 
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.DecimalType
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.storage.StorageLevel
 
@@ -58,7 +60,6 @@ class ConnectedComponents private[graphframes] (
 
   /**
    * Gets broadcast threshold in propagating component assignment.
-   *
    * @see [[setBroadcastThreshold()]]
    */
   def getBroadcastThreshold: Int = broadcastThreshold
@@ -73,7 +74,6 @@ class ConnectedComponents private[graphframes] (
    *     with skewed join optimization.
    *   - "graphx": Converts the graph to a GraphX graph and then uses the connected components
    *     implementation in GraphX.
-   *
    * @see [[ConnectedComponents.supportedAlgorithms]]
    */
   def setAlgorithm(value: String): this.type = {
@@ -85,7 +85,6 @@ class ConnectedComponents private[graphframes] (
 
   /**
    * Gets the connected component algorithm to use.
-   *
    * @see [[setAlgorithm()]].
    */
   def getAlgorithm: String = algorithm
@@ -102,7 +101,6 @@ class ConnectedComponents private[graphframes] (
    * Set a nonpositive value to disable checkpointing (not recommended for large graphs).
    * This parameter is only used when the algorithm is set to "graphframes".
    * Its default value might change in the future.
-   *
    * @see [[org.apache.spark.SparkContext.setCheckpointDir()]]
    */
   def setCheckpointInterval(value: Int): this.type = {
@@ -112,7 +110,6 @@ class ConnectedComponents private[graphframes] (
 
   /**
    * Gets checkpoint interval.
-   *
    * @see [[setCheckpointInterval()]]
    */
   def getCheckpointInterval: Int = checkpointInterval
@@ -148,7 +145,6 @@ private object ConnectedComponents extends Logging {
 
   /**
    * Returns the symmetric directed graph of the graph specified by input edges.
-   *
    * @param ee non-bidirectional edges
    */
   private def symmetrize(ee: DataFrame): DataFrame = {
@@ -194,7 +190,6 @@ private object ConnectedComponents extends Logging {
    *   - `src`, the ID of the vertex
    *   - `min_nbr`, the min ID of its neighbors
    *   - `cnt`, the total number of neighbors
-   *
    * @return a DataFrame with three columns
    */
   private def minNbrs(ee: DataFrame): DataFrame = {
@@ -270,7 +265,6 @@ private object ConnectedComponents extends Logging {
 
     val sqlContext = graph.sqlContext
     val sc = sqlContext.sparkContext
-    import sqlContext.implicits._
 
     val shouldCheckpoint = checkpointInterval > 0
     val checkpointDir: Option[String] = if (shouldCheckpoint) {
@@ -297,7 +291,7 @@ private object ConnectedComponents extends Logging {
 
     var converged = false
     var iteration = 1
-    var prevSum = Long.MaxValue
+    var prevSum: BigDecimal = null
     while (!converged) {
       // large-star step
       // compute min neighbors including self
@@ -346,9 +340,14 @@ private object ConnectedComponents extends Logging {
       ee.persist(StorageLevel.MEMORY_AND_DISK)
 
       // test convergence
-      val currSum = ee.select(sum(col(SRC))).as[Long].first()
+
+      // Taking the sum in DecimalType to preserve precision.
+      // We use 20 digits for long values and Spark SQL will add 10 digits for the sum.
+      // It should be able to handle 100 billion edges without overflow.
+      val currSum = ee.select(sum(col(SRC).cast(DecimalType(20, 0)))).first().getAs[BigDecimal](0)
       logInfo(s"$logPrefix Sum of assigned components in iteration $iteration: $currSum.")
       if (currSum == prevSum) {
+        // This also covers the case when currSum is null, which means no edges.
         converged = true
       } else {
         prevSum = currSum


### PR DESCRIPTION
This PR uses decimal type to compute the sum to avoid possible overflow issues. Note that even with long integer overflow, it is very unlikely to have `prevSum == currSum` happen before convergence. This PR just removed that possibility.

cc: @jkbradley 