### PR TITLE
[#121] add more unit tests to connected components

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -455,17 +455,19 @@ class GraphFrame private(
   }
 
   /**
-   * If the id type is not integral, it is the translation table that maps the original ids to the integral ids.
+   * Vertices with each vertex assigned a unique long ID.
+   * If the vertex ID type is integral, this casts the original IDs to long.
    *
    * Columns:
-   *  - $LONG_ID: the new ID
+   *  - $LONG_ID: the new ID of LongType
    *  - $ORIGINAL_ID: the ID provided by the user
    *  - $ATTR: all the original vertex attributes
    */
   private[graphframes] lazy val indexedVertices: DataFrame = {
     if (hasIntegralIdType) {
       val indexedVertices = vertices.select(nestAsCol(vertices, ATTR))
-      indexedVertices.select(col(ATTR + "." + ID).as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
+      indexedVertices.select(
+        col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
       val indexedVertices = zipWithUniqueId(vertices)
       indexedVertices.select(col("uniq_id").as(LONG_ID), col("row." + ID).as(ID), col("row").as(ATTR))

--- a/src/main/scala/org/graphframes/examples/Graphs.scala
+++ b/src/main/scala/org/graphframes/examples/Graphs.scala
@@ -21,7 +21,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.functions.{col, randn, udf}
+import org.apache.spark.sql.functions.{col, lit, randn, udf}
 
 import org.graphframes.GraphFrame
 import org.graphframes.GraphFrame._
@@ -45,12 +45,12 @@ class Graphs private[graphframes] () {
 
   /**
    * Returns a chain graph of the given size with Long ID type.
-   * The vertex IDs are 0, 1, ..., size-1, and the edges are (0, 1), (1, 2), ....
+   * The vertex IDs are 0, 1, ..., n-1, and the edges are (0, 1), (1, 2), ...., (n-2, n-1).
    */
-  def chain(size: Long): GraphFrame = {
-    require(size >= 0, s"Chain graph size must be nonnegative but got $size.")
-    val vertices = sqlContext.range(size).toDF(ID)
-    val edges = sqlContext.range(size - 1L).toDF(ID)
+  def chain(n: Long): GraphFrame = {
+    require(n >= 0, s"Chain graph size must be nonnegative but got $n.")
+    val vertices = sqlContext.range(n).toDF(ID)
+    val edges = sqlContext.range(n - 1L).toDF(ID)
       .select(col(ID).as(SRC), (col(ID) + 1L).as(DST))
     GraphFrame(vertices, edges)
   }
@@ -104,17 +104,14 @@ class Graphs private[graphframes] () {
   }
 
   /**
-   * A star graph, with a central element indexed 0 (the root) and the n other leaf vertices.
+   * Returns a star graph with Long ID type, consisting of a central element indexed 0 (the root)
+   * and the n other leaf vertices 1, 2, ..., n.
    * @param n the number of leaves
-   * @return
    */
-  def star(n: Int): GraphFrame = {
-    val vertices = sqlContext.createDataFrame(Seq((0, "root")) ++ (1 to n).map { i =>
-      (i, s"node-$i")
-    }).toDF("id", "v_attr1")
-    val edges = sqlContext.createDataFrame((1 to n).map { i =>
-      (i, 0, s"edge-$i")
-    }).toDF("src", "dst", "e_attr1")
+  def star(n: Long): GraphFrame = {
+    require(n >= 0L)
+    val vertices = sqlContext.range(n + 1L).toDF(ID)
+    val edges = sqlContext.range(1L, n + 1L).toDF(DST).withColumn(SRC, lit(0L))
     GraphFrame(vertices, edges)
   }
 

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -63,7 +63,7 @@ class ConnectedComponents private[graphframes] (
    */
   def getBroadcastThreshold: Int = broadcastThreshold
 
-  private var algorithm: String = _
+  private var algorithm: String = ALGO_GRAPHFRAMES
 
   /**
    * Sets the connected components algorithm to use (default: "graphframes").
@@ -260,6 +260,9 @@ private object ConnectedComponents extends Logging {
       algorithm: String,
       broadcastThreshold: Int,
       checkpointInterval: Int): DataFrame = {
+    require(supportedAlgorithms.contains(algorithm),
+      s"Supported algorithms are {${supportedAlgorithms.mkString(", ")}}, but got $algorithm.")
+
     if (algorithm == ALGO_GRAPHX) {
       return runGraphX(graph)
     }

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -95,10 +95,10 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
   }
 
   test("star graph") {
-    val n = 5
-    val g = Graphs.star(5)
+    val n = 5L
+    val g = Graphs.star(5L)
     val components = g.connectedComponents.run()
-    val expected = Set((0 to n).toSet) // star graph uses Int IDs instead of Long
+    val expected = Set((0L to n).toSet)
     assertComponents(components, expected)
   }
 


### PR DESCRIPTION
This PR adds more unit tests to connected components, mostly verifying the results on simple graph topologies. It does reveal two bugs:

1. I forgot to set the default value of `algorithm` param.
2. `indexedVertices` doesn't always cast ID to long.

cc: @jkbradley 