### PR TITLE
Set default checkpoint interval to 2 in connected components

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -207,7 +207,7 @@ class GraphFrame(object):
 
     # Standard algorithms
 
-    def connectedComponents(self, algorithm = "graphframes", checkpointInterval = 1,
+    def connectedComponents(self, algorithm = "graphframes", checkpointInterval = 2,
                             broadcastThreshold = 1000000):
         """
         Computes the connected components of the graph.
@@ -216,7 +216,7 @@ class GraphFrame(object):
 
         :param algorithm: connected components algorithm to use (default: "graphframes")
           Supported algorithms are "graphframes" and "graphx".
-        :param checkpointInterval: checkpoint interval in terms of number of iterations (default: 1)
+        :param checkpointInterval: checkpoint interval in terms of number of iterations (default: 2)
         :param broadcastThreshold: broadcast threshold in propagating component assignments
           (default: 1000000)
 

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -94,12 +94,12 @@ class ConnectedComponents private[graphframes] (
    */
   def getAlgorithm: String = algorithm
 
-  private var checkpointInterval: Int = 1
+  private var checkpointInterval: Int = 2
 
   /**
-   * Sets checkpoint interval in terms of number of iterations (default: 1).
-   * Checkpointing regularly helps recover from failures, clean shuffle files, and shorten the
-   * lineage of the computation graph.
+   * Sets checkpoint interval in terms of number of iterations (default: 2).
+   * Checkpointing regularly helps recover from failures, clean shuffle files, shorten the
+   * lineage of the computation graph, and reduce the complexity of plan optimization.
    * Checkpoint data is saved under [[org.apache.spark.SparkContext.getCheckpointDir]] with
    * prefix "connected-components".
    * If the checkpoint directory is not set, this throws an [[java.io.IOException]].

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -37,7 +37,7 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     val cc = g.connectedComponents
     assert(cc.getAlgorithm === "graphframes")
     assert(cc.getBroadcastThreshold === 1000000)
-    assert(cc.getCheckpointInterval === 1)
+    assert(cc.getCheckpointInterval === 2)
   }
 
   test("empty graph") {
@@ -163,8 +163,8 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
 
     val cc = new ConnectedComponents(friends)
-    assert(cc.getCheckpointInterval === 1,
-      s"Default checkpoint interval should be 1, but got ${cc.getCheckpointInterval}.")
+    assert(cc.getCheckpointInterval === 2,
+      s"Default checkpoint interval should be 2, but got ${cc.getCheckpointInterval}.")
 
     val checkpointDir = sc.getCheckpointDir
     assert(checkpointDir.nonEmpty)


### PR DESCRIPTION
I tested the implementation on a relatively large graph. It seems setting the checkpoint interval to 2 hit the balance between checkpoint overhead and complexity of query plan optimization. This is what I got:

* =1: 11.2 mins, 50 jobs
* =2: 8.6 mins, 42 jobs
* =3: ran out of memory after 30 mins ...

cc: @thunterdb 