### PR TITLE
Re-add note about Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ We welcome open source contributions as well!
 - 0.2.0 release for Spark 2.0 (work of @felixcheung)
 - 0.3.0
   - DataFrame-based connected components implementation
+  - added support for Python 3
   - removed support for Spark 1.4 and 1.5


### PR DESCRIPTION
I talked @mengxr out of adding this in the first time around [here in this PR](https://github.com/graphframes/graphframes/pull/138), but it looks like GrapheFrames works fine with Python 3, and I've been using it as such for many weeks now.