### PR TITLE
[160] ConnectedComponents checkpointing should construct FileSystem using Path

### DIFF
--- a/python/run-tests.sh
+++ b/python/run-tests.sh
@@ -54,7 +54,7 @@ for assembly in $assembly_path/graphframes-assembly*.jar ; do
   JAR_PATH=$assembly
 done
 
-export PYSPARK_SUBMIT_ARGS="--driver-memory 2g --jars $JAR_PATH pyspark-shell "
+export PYSPARK_SUBMIT_ARGS="--driver-memory 2g --executor-memory 2g --jars $JAR_PATH pyspark-shell "
 
 export PYTHONPATH=$PYTHONPATH:$SPARK_HOME/python:$LIBS:.
 

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -156,8 +156,6 @@ object ConnectedComponents extends Logging {
   private val ALGO_GRAPHX = "graphx"
   private val ALGO_GRAPHFRAMES = "graphframes"
 
-  @transient private var fileSystem: FileSystem = null
-
   /**
    * Supported algorithms in [[org.graphframes.lib.ConnectedComponents.setAlgorithm]]: "graphframes"
    * and "graphx".
@@ -339,10 +337,7 @@ object ConnectedComponents extends Logging {
         // remove previous checkpoint
         if (iteration > checkpointInterval) {
           val path = new Path(s"${checkpointDir.get}/${iteration - checkpointInterval}")
-          if (fileSystem == null) {
-            fileSystem = path.getFileSystem(sc.hadoopConfiguration)
-          }
-          fileSystem.delete(path, true)
+          path.getFileSystem(sc.hadoopConfiguration).delete(path, true)
         }
 
         System.gc() // hint Spark to clean shuffle directories

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -156,6 +156,8 @@ object ConnectedComponents extends Logging {
   private val ALGO_GRAPHX = "graphx"
   private val ALGO_GRAPHFRAMES = "graphframes"
 
+  @transient private var fileSystem: FileSystem = null
+
   /**
    * Supported algorithms in [[org.graphframes.lib.ConnectedComponents.setAlgorithm]]: "graphframes"
    * and "graphx".
@@ -336,8 +338,11 @@ object ConnectedComponents extends Logging {
 
         // remove previous checkpoint
         if (iteration > checkpointInterval) {
-          FileSystem.get(sc.hadoopConfiguration)
-            .delete(new Path(s"${checkpointDir.get}/${iteration - checkpointInterval}"), true)
+          val path = new Path(s"${checkpointDir.get}/${iteration - checkpointInterval}")
+          if (fileSystem == null) {
+            fileSystem = path.getFileSystem(sc.hadoopConfiguration)
+          }
+          fileSystem.delete(path, true)
         }
 
         System.gc() // hint Spark to clean shuffle directories


### PR DESCRIPTION
to make sure we are using the right FileSystem.
took clue from https://github.com/apache/spark/blob/master/streaming/src/main/scala/org/apache/spark/streaming/dstream/DStreamCheckpointData.scala#L88

fix #160