### PR TITLE
[157][166] Updated docs for 0.4.0 doc preparation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ include:
 
 # These allow the documentation to be updated with newer releases
 # of Spark, Scala, and Mesos.
-GRAPHFRAMES_VERSION: 0.4.0-SNAPSHOT
+GRAPHFRAMES_VERSION: 0.4.0
 #SCALA_BINARY_VERSION: "2.10"
 #SCALA_VERSION: "2.10.4"
 #MESOS_VERSION: 0.21.0

--- a/docs/_plugins/copy_api_dirs.rb
+++ b/docs/_plugins/copy_api_dirs.rb
@@ -67,6 +67,10 @@ if not (ENV['SKIP_API'] == '1')
 
     puts "Moving to python/docs directory and building sphinx."
     cd("../python/docs")
+    if not (ENV['SPARK_HOME'])
+      raise("Python API docs cannot be generated if SPARK_HOME is not set.")
+    end
+    system({"PACKAGE_VERSION"=>version}, "make clean") || raise("Python doc clean failed")
     system({"PACKAGE_VERSION"=>version}, "make html") || raise("Python doc generation failed")
 
     puts "Moving back into home dir."

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -525,6 +525,10 @@ assigned a component ID.
 
 See [Wikipedia](https://en.wikipedia.org/wiki/Connected_component_(graph_theory)) for background.
 
+NOTE: With GraphFrames 0.3.0 and later releases, the default Connected Components algorithm
+requires setting a Spark checkpoint directory.  Users can revert to the old algorithm using
+`.setAlgorithm("graphx")`.
+
 <div class="codetabs">
 
 <div data-lang="scala"  markdown="1">

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -31,8 +31,7 @@ needs_sphinx = '1.2'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
-    'epytext',
-    'underscores'
+    'epytext'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
* Removed "SNAPSHOT" label in config.yml for docs
* Updated ruby script for building Python docs to fail more loudly if SPARK_HOME is not present (which I tested manually) and to clean the build (which prevents build failures when built docs already exist)
* Added small clarification to user guide