### PR TITLE
[#184] Parallel Personalized PageRank Wrapper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,8 @@ licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 spAppendScalaVersion := true
 
 // Add Spark components this package depends on, e.g, "mllib", ....
-sparkComponents ++= Seq("graphx", "sql")
+// We need mllib for sparse vector encoded parallel personalized PageRank
+sparkComponents ++= Seq("graphx", "sql", "mllib")
 
 // uncomment and change the value below to change the directory where your zip artifact will be created
 // spDistDirectory := target.value

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,6 @@ licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")
 spAppendScalaVersion := true
 
 // Add Spark components this package depends on, e.g, "mllib", ....
-// We need mllib for sparse vector encoded parallel personalized PageRank
 sparkComponents ++= Seq("graphx", "sql", "mllib")
 
 // uncomment and change the value below to change the directory where your zip artifact will be created

--- a/build.sbt
+++ b/build.sbt
@@ -44,15 +44,21 @@ libraryDependencies += "org.scalatest" %% "scalatest" % defaultScalaTestVer % "t
 
 // These versions are ancient, but they cross-compile around scala 2.10 and 2.11.
 // Update them when dropping support for scala 2.10
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging-api" % "2.1.2"
-
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
+libraryDependencies ++= Seq(
+  "com.typesafe.scala-logging" %% "scala-logging-api" % "2.1.2",
+  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
+)
 
 parallelExecution := false
 
 unmanagedSourceDirectories in Compile ++=
-  Seq(baseDirectory.value / "src" / "main" /
-    (if (sparkBranch == "1.6") "spark-1.x" else "spark-2.x"))
+  Seq(baseDirectory.value / "src" / "main" / {
+    sparkBranch match {
+      case ver if ver.startsWith("1.") => "spark-1.x"
+      case ver if ver.startsWith("2.0") => "spark-2.0"
+      case _ => "spark-2.x"
+    }
+  })
 
 scalacOptions in (Compile, doc) ++= Seq(
   "-groups",

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -367,6 +367,15 @@ class GraphFrame private(
   def pageRank: PageRank = new PageRank(this)
 
   /**
+    * Parallel personalized PageRank algorithm.
+    * 
+    * See [[org.graphframes.lib.ParallelPersonalizedPageRank]] for more details.
+    * 
+    * @group stdlib
+    */
+  def parallelPersonalizedPageRank: ParallelPersonalizedPageRank = new ParallelPersonalizedPageRank(this)
+
+  /**
    * Shortest paths algorithm.
    *
    * See [[org.graphframes.lib.ShortestPaths]] for more details.

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -40,166 +40,22 @@ import org.graphframes.pattern._
  * @groupname degree Graph topology
  * @groupname motif Motif finding
  */
-class GraphFrame private (
+class GraphFrame private(
     @transient private val _vertices: DataFrame,
-    @transient private val _edges: DataFrame)
-    extends Logging
-    with Serializable {
+    @transient private val _edges: DataFrame) extends Logging with Serializable {
 
   import GraphFrame._
 
-  /**
-   * Returns triplets: (source vertex)-[edge]->(destination vertex) for all edges in the graph.
-   * The DataFrame returned has 3 columns, with names: [[GraphFrame.SRC]], [[GraphFrame.EDGE]],
-   * and [[GraphFrame.DST]].  The 2 vertex columns have schema matching [[GraphFrame.vertices]],
-   * and the edge column has a schema matching [[GraphFrame.edges]].
-   *
-   * @group structure
-   */
-  lazy val triplets: DataFrame = find(s"($SRC)-[$EDGE]->($DST)")
-
-  /**
-   * The out-degree of each vertex in the graph, returned as a DataFrame with two columns:
-   *  - [[GraphFrame.ID]] the ID of the vertex
-   *  - "outDegree" (integer) storing the out-degree of the vertex
-   * Note that vertices with 0 out-edges are not returned in the result.
-   *
-   * @group degree
-   */
-  @transient lazy val outDegrees: DataFrame = {
-    edges.groupBy(edges(SRC).as(ID)).agg(count("*").cast("int").as("outDegree"))
-  }
-
-  /**
-   * The in-degree of each vertex in the graph, returned as a DataFame with two columns:
-   *  - [[GraphFrame.ID]] the ID of the vertex
-   * "- "inDegree" (int) storing the in-degree of the vertex
-   * Note that vertices with 0 in-edges are not returned in the result.
-   *
-   * @group degree
-   */
-  @transient lazy val inDegrees: DataFrame = {
-    edges.groupBy(edges(DST).as(ID)).agg(count("*").cast("int").as("inDegree"))
-  }
-
-  /**
-   * The degree of each vertex in the graph, returned as a DataFrame with two columns:
-   *  - [[GraphFrame.ID]] the ID of the vertex
-   *  - 'degree' (integer) the degree of the vertex
-   * Note that vertices with 0 edges are not returned in the result.
-   *
-   * @group degree
-   */
-  @transient lazy val degrees: DataFrame = {
-    edges
-      .select(explode(array(SRC, DST)).as(ID))
-      .groupBy(ID)
-      .agg(count("*").cast("int").as("degree"))
-  }
-
-  /**
-   * True if the id type can be cast to Long.
-   *
-   * This is important for performance reasons. The underlying graphx
-   * implementation only deals with Long types.
-   */
-  private[graphframes] lazy val hasIntegralIdType: Boolean = {
-    vertices.schema(ID).dataType match {
-      case _ @(ByteType | IntegerType | LongType | ShortType) => true
-      case _ => false
-    }
-  }
-
-  /**
-   * Vertices with each vertex assigned a unique long ID.
-   * If the vertex ID type is integral, this casts the original IDs to long.
-   *
-   * Columns:
-   *  - $LONG_ID: the new ID of LongType
-   *  - $ORIGINAL_ID: the ID provided by the user
-   *  - $ATTR: all the original vertex attributes
-   */
-  private[graphframes] lazy val indexedVertices: DataFrame = {
-    if (hasIntegralIdType) {
-      val indexedVertices = vertices.select(nestAsCol(vertices, ATTR))
-      indexedVertices.select(
-        col(ATTR + "." + ID).cast("long").as(LONG_ID),
-        col(ATTR + "." + ID).as(ID),
-        col(ATTR))
-    } else {
-      val indexedVertices = zipWithUniqueId(vertices)
-      indexedVertices.select(
-        col("uniq_id").as(LONG_ID),
-        col("row." + ID).as(ID),
-        col("row").as(ATTR))
-    }
-  }
-
-  /**
-   * Columns:
-   *  - $SRC
-   *  - $LONG_SRC
-   *  - $DST
-   *  - $LONG_DST
-   *  - $ATTR
-   */
-  private[graphframes] lazy val indexedEdges: DataFrame = {
-    val packedEdges = edges.select(col(SRC), col(DST), nestAsCol(edges, ATTR))
-    if (hasIntegralIdType) {
-      packedEdges.select(
-        col(SRC),
-        col(SRC).cast("long").as(LONG_SRC),
-        col(DST),
-        col(DST).cast("long").as(LONG_DST),
-        col(ATTR))
-    } else {
-      val threshold = broadcastThreshold
-      val hubs: Set[Any] = degrees
-        .filter(col("degree") >= threshold)
-        .select(ID)
-        .collect()
-        .map(_.get(0))
-        .toSet
-      val indexedSourceEdges = GraphFrame.skewedJoin(
-        packedEdges,
-        indexedVertices.select(col(ID).as(SRC), col(LONG_ID).as(LONG_SRC)),
-        SRC,
-        hubs,
-        "GraphFrame.indexedEdges:")
-      val indexedEdges = GraphFrame.skewedJoin(
-        indexedSourceEdges,
-        indexedVertices.select(col(ID).as(DST), col(LONG_ID).as(LONG_DST)),
-        DST,
-        hubs,
-        "GraphFrame.indexedEdges:")
-      indexedEdges.select(SRC, LONG_SRC, DST, LONG_DST, ATTR)
-    }
-  }
-
-  // ============== Basic structural methods ============
-  /**
-   * A cached conversion of this graph to the GraphX structure. All the data is stripped away.
-   */
-  @transient lazy private[graphframes] val cachedTopologyGraphX: Graph[Unit, Unit] = {
-    cachedGraphX.mapVertices((_, _) => ()).mapEdges(e => ())
-  }
-
-  /**
-   * A cached conversion of this graph to the GraphX structure, with the data stored for each edge and vertex.
-   */
-  @transient private lazy val cachedGraphX: Graph[Row, Row] = {
-    toGraphX
-  }
+  /** Default constructor is provided to support serialization */
+  protected def this() = this(null, null)
 
   override def toString: String = {
     // We call select on the vertices and edges to ensure that ID, SRC, DST always come first
     // in the printed schema.
-    val v = vertices.select(ID, vertices.columns.filter(_ != ID): _*).toString
-    val e = edges.select(SRC, DST +: edges.columns.filter(c => c != SRC && c != DST): _*).toString
+    val v = vertices.select(ID, vertices.columns.filter(_ != ID) :_ *).toString
+    val e = edges.select(SRC, DST +: edges.columns.filter(c => c != SRC && c != DST) :_ *).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
-
-  // ============================ Conversions ========================================
 
   /**
    * Persist the dataframe representation of vertices and edges of the graph with the default
@@ -218,6 +74,41 @@ class GraphFrame private (
     edges.persist()
     this
   }
+
+  /**
+   * Persist the dataframe representation of vertices and edges of the graph with the given
+   * storage level.
+   * @param newLevel  One of: `MEMORY_ONLY`, `MEMORY_AND_DISK`, `MEMORY_ONLY_SER`,
+   * `MEMORY_AND_DISK_SER`, `DISK_ONLY`, `MEMORY_ONLY_2`, `MEMORY_AND_DISK_2`, etc..
+   */
+  def persist(newLevel: StorageLevel): this.type = {
+    vertices.persist(newLevel)
+    edges.persist(newLevel)
+    this
+  }
+
+  /**
+   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
+   * remove all blocks for it from memory and disk.
+   */
+  def unpersist(): this.type = {
+    vertices.unpersist()
+    edges.unpersist()
+    this
+  }
+
+  /**
+   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
+   * remove all blocks for it from memory and disk.
+   * @param blocking  Whether to block until all blocks are deleted.
+   */
+  def unpersist(blocking: Boolean): this.type = {
+    vertices.unpersist(blocking)
+    edges.unpersist(blocking)
+    this
+  }
+
+  // ============== Basic structural methods ============
 
   /**
    * The dataframe representation of the vertices of the graph.
@@ -259,41 +150,16 @@ class GraphFrame private (
   }
 
   /**
-   * Persist the dataframe representation of vertices and edges of the graph with the given
-   * storage level.
+   * Returns triplets: (source vertex)-[edge]->(destination vertex) for all edges in the graph.
+   * The DataFrame returned has 3 columns, with names: [[GraphFrame.SRC]], [[GraphFrame.EDGE]],
+   * and [[GraphFrame.DST]].  The 2 vertex columns have schema matching [[GraphFrame.vertices]],
+   * and the edge column has a schema matching [[GraphFrame.edges]].
    *
-   * @param newLevel One of: `MEMORY_ONLY`, `MEMORY_AND_DISK`, `MEMORY_ONLY_SER`,
-   *                 `MEMORY_AND_DISK_SER`, `DISK_ONLY`, `MEMORY_ONLY_2`, `MEMORY_AND_DISK_2`, etc..
+   * @group structure
    */
-  def persist(newLevel: StorageLevel): this.type = {
-    vertices.persist(newLevel)
-    edges.persist(newLevel)
-    this
-  }
+  lazy val triplets: DataFrame = find(s"($SRC)-[$EDGE]->($DST)")
 
-  // ============================ Degree metrics =======================================
-
-  /**
-   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
-   * remove all blocks for it from memory and disk.
-   */
-  def unpersist(): this.type = {
-    vertices.unpersist()
-    edges.unpersist()
-    this
-  }
-
-  /**
-   * Mark the dataframe representation of vertices and edges of the graph as non-persistent, and
-   * remove all blocks for it from memory and disk.
-   *
-   * @param blocking Whether to block until all blocks are deleted.
-   */
-  def unpersist(blocking: Boolean): this.type = {
-    vertices.unpersist(blocking)
-    edges.unpersist(blocking)
-    this
-  }
+  // ============================ Conversions ========================================
 
   /**
    * Converts this [[GraphFrame]] instance to a GraphX `Graph`.
@@ -311,37 +177,20 @@ class GraphFrame private (
    */
   def toGraphX: Graph[Row, Row] = {
     if (hasIntegralIdType) {
-      val vv = vertices.select(col(ID).cast(LongType), nestAsCol(vertices, ATTR)).rdd.map {
-        case Row(id: Long, attr: Row) => (id, attr)
-      }
-      val ee = edges
-        .select(col(SRC).cast(LongType), col(DST).cast(LongType), nestAsCol(edges, ATTR))
-        .rdd
-        .map { case Row(srcId: Long, dstId: Long, attr: Row) => Edge(srcId, dstId, attr) }
+      val vv = vertices.select(col(ID).cast(LongType), nestAsCol(vertices, ATTR))
+        .rdd.map { case Row(id: Long, attr: Row) => (id, attr) }
+      val ee = edges.select(col(SRC).cast(LongType), col(DST).cast(LongType), nestAsCol(edges, ATTR))
+        .rdd.map { case Row(srcId: Long, dstId: Long, attr: Row) => Edge(srcId, dstId, attr) }
       Graph(vv, ee)
     } else {
       // Compute Long vertex IDs
-      val vv = indexedVertices.select(LONG_ID, ATTR).rdd.map {
-        case Row(long_id: Long, attr: Row) => (long_id, attr)
-      }
-      val ee = indexedEdges.select(LONG_SRC, LONG_DST, ATTR).rdd.map {
-        case Row(long_src: Long, long_dst: Long, attr: Row) =>
-          Edge(long_src, long_dst, attr)
+      val vv = indexedVertices.select(LONG_ID, ATTR).rdd.map { case Row(long_id: Long, attr: Row) => (long_id, attr) }
+      val ee = indexedEdges.select(LONG_SRC, LONG_DST, ATTR).rdd.map { case Row(long_src: Long, long_dst: Long, attr: Row) =>
+        Edge(long_src, long_dst, attr)
       }
       Graph(vv, ee)
     }
   }
-
-  // ============================ Motif finding ========================================
-
-  /**
-   * Version of [[vertexColumns]] which maps column names to indices in the Rows.
-   *
-   * @group conversions
-   */
-  def vertexColumnMap: Map[String, Int] = vertexColumns.zipWithIndex.toMap
-
-  // ======================== Other queries ===================================
 
   /**
    * The column names in the [[vertices]] DataFrame, in order.
@@ -355,13 +204,11 @@ class GraphFrame private (
   def vertexColumns: Array[String] = vertices.columns
 
   /**
-   * Version of [[edgeColumns]] which maps column names to indices in the Rows.
+   * Version of [[vertexColumns]] which maps column names to indices in the Rows.
    *
    * @group conversions
    */
-  def edgeColumnMap: Map[String, Int] = edgeColumns.zipWithIndex.toMap
-
-  // **** Standard library ****
+  def vertexColumnMap: Map[String, Int] = vertexColumns.zipWithIndex.toMap
 
   /**
    * The vertex names in the [[vertices]] DataFrame, in order.
@@ -375,6 +222,53 @@ class GraphFrame private (
   def edgeColumns: Array[String] = edges.columns
 
   /**
+   * Version of [[edgeColumns]] which maps column names to indices in the Rows.
+   *
+   * @group conversions
+   */
+  def edgeColumnMap: Map[String, Int] = edgeColumns.zipWithIndex.toMap
+
+  // ============================ Degree metrics =======================================
+
+  /**
+   * The out-degree of each vertex in the graph, returned as a DataFrame with two columns:
+   *  - [[GraphFrame.ID]] the ID of the vertex
+   *  - "outDegree" (integer) storing the out-degree of the vertex
+   * Note that vertices with 0 out-edges are not returned in the result.
+   *
+   * @group degree
+   */
+  @transient lazy val outDegrees: DataFrame = {
+    edges.groupBy(edges(SRC).as(ID)).agg(count("*").cast("int").as("outDegree"))
+  }
+
+  /**
+   * The in-degree of each vertex in the graph, returned as a DataFame with two columns:
+   *  - [[GraphFrame.ID]] the ID of the vertex
+   * "- "inDegree" (int) storing the in-degree of the vertex
+   * Note that vertices with 0 in-edges are not returned in the result.
+   *
+   * @group degree
+   */
+  @transient lazy val inDegrees: DataFrame = {
+    edges.groupBy(edges(DST).as(ID)).agg(count("*").cast("int").as("inDegree"))
+  }
+
+  /**
+   * The degree of each vertex in the graph, returned as a DataFrame with two columns:
+   *  - [[GraphFrame.ID]] the ID of the vertex
+   *  - 'degree' (integer) the degree of the vertex
+   * Note that vertices with 0 edges are not returned in the result.
+   *
+   * @group degree
+   */
+  @transient lazy val degrees: DataFrame = {
+    edges.select(explode(array(SRC, DST)).as(ID)).groupBy(ID).agg(count("*").cast("int").as("degree"))
+  }
+
+  // ============================ Motif finding ========================================
+
+  /**
    * Motif finding: Searching the graph for structural patterns
    *
    * Motif finding uses a simple Domain-Specific Language (DSL) for expressing structural queries.
@@ -386,43 +280,45 @@ class GraphFrame private (
    *
    * DSL for expressing structural patterns:
    *  - The basic unit of a pattern is an edge.
-   * For example, `"(a)-[e]->(b)"` expresses an edge `e` from vertex `a` to vertex `b`.
-   * Note that vertices are denoted by parentheses `(a)`, while edges are denoted by
-   * square brackets `[e]`.
+   *    For example, `"(a)-[e]->(b)"` expresses an edge `e` from vertex `a` to vertex `b`.
+   *    Note that vertices are denoted by parentheses `(a)`, while edges are denoted by
+   *    square brackets `[e]`.
    *  - A pattern is expressed as a union of edges. Edge patterns can be joined with semicolons.
-   * Motif `"(a)-[e]->(b); (b)-[e2]->(c)"` specifies two edges from `a` to `b` to `c`.
+   *    Motif `"(a)-[e]->(b); (b)-[e2]->(c)"` specifies two edges from `a` to `b` to `c`.
    *  - Within a pattern, names can be assigned to vertices and edges.  For example,
-   * `"(a)-[e]->(b)"` has three named elements: vertices `a,b` and edge `e`.
-   * These names serve two purposes:
+   *    `"(a)-[e]->(b)"` has three named elements: vertices `a,b` and edge `e`.
+   *    These names serve two purposes:
    *     - The names can identify common elements among edges.  For example,
-   * `"(a)-[e]->(b); (b)-[e2]->(c)"` specifies that the same vertex `b` is the destination
-   * of edge `e` and source of edge `e2`.
+   *       `"(a)-[e]->(b); (b)-[e2]->(c)"` specifies that the same vertex `b` is the destination
+   *       of edge `e` and source of edge `e2`.
    *     - The names are used as column names in the result `DataFrame`.  If a motif contains
-   * named vertex `a`, then the result `DataFrame` will contain a column "a" which is a
-   * `StructType` with sub-fields equivalent to the schema (columns) of
-   * [[GraphFrame.vertices]]. Similarly, an edge `e` in a motif will produce a column "e"
-   * in the result `DataFrame` with sub-fields equivalent to the schema (columns) of
-   * [[GraphFrame.edges]].
+   *       named vertex `a`, then the result `DataFrame` will contain a column "a" which is a
+   *       `StructType` with sub-fields equivalent to the schema (columns) of
+   *       [[GraphFrame.vertices]]. Similarly, an edge `e` in a motif will produce a column "e"
+   *       in the result `DataFrame` with sub-fields equivalent to the schema (columns) of
+   *       [[GraphFrame.edges]].
    *  - It is acceptable to omit names for vertices or edges in motifs when not needed.
    *    E.g., `"(a)-[]->(b)"` expresses an edge between vertices `a,b` but does not assign a name
-   * to the edge.  There will be no column for the anonymous edge in the result `DataFrame`.
-   * Similarly, `"(a)-[e]->()"` indicates an out-edge of vertex `a` but does not name
-   * the destination vertex.
+   *    to the edge.  There will be no column for the anonymous edge in the result `DataFrame`.
+   *    Similarly, `"(a)-[e]->()"` indicates an out-edge of vertex `a` but does not name
+   *    the destination vertex.
    *  - An edge can be negated to indicate that the edge should *not* be present in the graph.
    *    E.g., `"(a)-[]->(b); !(b)-[]->(a)"` finds edges from `a` to `b` for which there is *no*
-   * edge from `b` to `a`.
+   *    edge from `b` to `a`.
    *
    * More complex queries, such as queries which operate on vertex or edge attributes,
    * can be expressed by applying filters to the result `DataFrame`.
    *
-   * @param pattern Pattern specifying a motif to search for.
-   * @return `DataFrame` containing all instances of the motif.
+   * @param pattern  Pattern specifying a motif to search for.
+   * @return  `DataFrame` containing all instances of the motif.
    * @group motif
    */
   def find(pattern: String): DataFrame = {
     val (df, names) = findSimple(Nil, None, Seq(), Pattern.parse(pattern))
-    if (names.isEmpty) df else df.select(names.head, names.tail: _*)
+    if (names.isEmpty) df else df.select(names.head, names.tail : _*)
   }
+
+  // ======================== Other queries ===================================
 
   /**
    * Breadth-first search (BFS)
@@ -439,6 +335,9 @@ class GraphFrame private (
    * See [[org.graphframes.lib.AggregateMessages AggregateMessages]] for detailed documentation.
    */
   def aggregateMessages: AggregateMessages = new AggregateMessages(this)
+
+
+  // **** Standard library ****
 
   /**
    * Connected component algorithm.
@@ -468,16 +367,14 @@ class GraphFrame private (
   def pageRank: PageRank = new PageRank(this)
 
   /**
-   * Parallel personalized PageRank algorithm.
-   *
-   * See [[org.graphframes.lib.ParallelPersonalizedPageRank]] for more details.
-   *
-   * @group stdlib
-   */
+    * Parallel personalized PageRank algorithm.
+    *
+    * See [[org.graphframes.lib.ParallelPersonalizedPageRank]] for more details.
+    *
+    * @group stdlib
+    */
   def parallelPersonalizedPageRank: ParallelPersonalizedPageRank =
     new ParallelPersonalizedPageRank(this)
-
-  // ========= Motif finding (private) =========
 
   /**
    * Shortest paths algorithm.
@@ -487,8 +384,6 @@ class GraphFrame private (
    * @group stdlib
    */
   def shortestPaths: ShortestPaths = new ShortestPaths(this)
-
-  // ========= Other private methods ===========
 
   /**
    * Strongly connected components algorithm.
@@ -518,23 +413,23 @@ class GraphFrame private (
    */
   def triangleCount: TriangleCount = new TriangleCount(this)
 
-  /** Default constructor is provided to support serialization */
-  protected def this() = this(null, null)
+  // ========= Motif finding (private) =========
+
 
   /**
    * Primary method implementing motif finding.
    * This recursive method handles one pattern (via [[findIncremental()]] on each iteration,
    * augmenting the `DataFrame` in prevDF with each new pattern.
    *
-   * @param prevPatterns      Patterns already handled
-   * @param prevDF            Current DataFrame based on prevPatterns
-   * @param prevNames         Current sequence of column names in the order as specified by prevPatterns
-   *                          For instance, `"(a)-[e]->(b)"` is Seq("a", "e", "b")
-   *                          `"(a)-[e]->(b); (b)-[]->(c)"` is Seq("a", "e", "b", "c")
-   * @param remainingPatterns Patterns not yet handled
+   * @param prevPatterns  Patterns already handled
+   * @param prevDF  Current DataFrame based on prevPatterns
+   * @param prevNames Current sequence of column names in the order as specified by prevPatterns
+   *                  For instance, `"(a)-[e]->(b)"` is Seq("a", "e", "b")
+   *                  `"(a)-[e]->(b); (b)-[]->(c)"` is Seq("a", "e", "b", "c")
+   * @param remainingPatterns  Patterns not yet handled
    * @return `DataFrame` augmented with the next pattern, or the previous DataFrame if done
-   *         Seq[String] sequence of column names for the `DataFrame` appended to in order
-   *         as specified by the next pattern
+   *        Seq[String] sequence of column names for the `DataFrame` appended to in order
+   *        as specified by the next pattern
    */
   private def findSimple(
       prevPatterns: Seq[Pattern],
@@ -549,186 +444,102 @@ class GraphFrame private (
     }
   }
 
+  // ========= Other private methods ===========
+
   private[graphframes] def sqlContext: SQLContext = vertices.sqlContext
+
+  /**
+   * True if the id type can be cast to Long.
+   *
+   * This is important for performance reasons. The underlying graphx
+   * implementation only deals with Long types.
+   */
+  private[graphframes] lazy val hasIntegralIdType: Boolean = {
+    vertices.schema(ID).dataType match {
+      case _ @ (ByteType | IntegerType | LongType | ShortType) => true
+      case _ => false
+    }
+  }
+
+  /**
+   * Vertices with each vertex assigned a unique long ID.
+   * If the vertex ID type is integral, this casts the original IDs to long.
+   *
+   * Columns:
+   *  - $LONG_ID: the new ID of LongType
+   *  - $ORIGINAL_ID: the ID provided by the user
+   *  - $ATTR: all the original vertex attributes
+   */
+  private[graphframes] lazy val indexedVertices: DataFrame = {
+    if (hasIntegralIdType) {
+      val indexedVertices = vertices.select(nestAsCol(vertices, ATTR))
+      indexedVertices.select(
+        col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
+    } else {
+      val indexedVertices = zipWithUniqueId(vertices)
+      indexedVertices.select(col("uniq_id").as(LONG_ID), col("row." + ID).as(ID), col("row").as(ATTR))
+    }
+  }
+
+  /**
+   * Columns:
+   *  - $SRC
+   *  - $LONG_SRC
+   *  - $DST
+   *  - $LONG_DST
+   *  - $ATTR
+   */
+  private[graphframes] lazy val indexedEdges: DataFrame = {
+    val packedEdges = edges.select(col(SRC), col(DST), nestAsCol(edges, ATTR))
+    if (hasIntegralIdType) {
+      packedEdges.select(
+        col(SRC), col(SRC).cast("long").as(LONG_SRC),
+        col(DST), col(DST).cast("long").as(LONG_DST),
+        col(ATTR))
+    } else {
+      val threshold = broadcastThreshold
+      val hubs: Set[Any] = degrees.filter(col("degree") >= threshold).select(ID)
+        .collect().map(_.get(0)).toSet
+      val indexedSourceEdges = GraphFrame.skewedJoin(
+        packedEdges,
+        indexedVertices.select(col(ID).as(SRC), col(LONG_ID).as(LONG_SRC)),
+        SRC, hubs, "GraphFrame.indexedEdges:")
+      val indexedEdges = GraphFrame.skewedJoin(
+        indexedSourceEdges,
+        indexedVertices.select(col(ID).as(DST), col(LONG_ID).as(LONG_DST)),
+        DST, hubs, "GraphFrame.indexedEdges:")
+      indexedEdges.select(SRC, LONG_SRC, DST, LONG_DST, ATTR)
+    }
+  }
+
+  /**
+   * A cached conversion of this graph to the GraphX structure. All the data is stripped away.
+   */
+  @transient lazy private[graphframes] val cachedTopologyGraphX: Graph[Unit, Unit] = {
+    cachedGraphX.mapVertices((_, _) => ()).mapEdges(e => ())
+  }
+
+  /**
+   * A cached conversion of this graph to the GraphX structure, with the data stored for each edge and vertex.
+   */
+  @transient private lazy val cachedGraphX: Graph[Row, Row] = { toGraphX }
 
 }
 
+
 object GraphFrame extends Serializable with Logging {
-
-  /** Column name for vertex IDs in [[GraphFrame.vertices]] */
-  val ID: String = "id"
-
-  /**
-   * Column name for source vertices of edges.
-   *  - In [[GraphFrame.edges]], this is a column of vertex IDs.
-   *  - In [[GraphFrame.triplets]], this is a column of vertices with schema matching
-   * [[GraphFrame.vertices]].
-   */
-  val SRC: String = "src"
-
-  /**
-   * Column name for destination vertices of edges.
-   *  - In [[GraphFrame.edges]], this is a column of vertex IDs.
-   *  - In [[GraphFrame.triplets]], this is a column of vertices with schema matching
-   * [[GraphFrame.vertices]].
-   */
-  val DST: String = "dst"
-
-  /**
-   * Column name for edge in [[GraphFrame.triplets]].  In [[GraphFrame.triplets]],
-   * this is a column of edges with schema matching [[GraphFrame.edges]].
-   */
-  val EDGE: String = "edge"
-
-  /** Default name for attribute columns when converting from GraphX [[Graph]] format */
-  private[graphframes] val ATTR: String = "attr"
-
-  // ============================ Constructors and converters =================================
-  /**
-   * The integral id that is used as a surrogate id when using graphX implementation
-   */
-  private[graphframes] val LONG_ID: String = "new_id"
-  private[graphframes] val LONG_SRC: String = "new_src"
-  private[graphframes] val LONG_DST: String = "new_dst"
-  private[graphframes] val GX_ATTR: String = "graphx_attr"
-
-  // ============== Private constants ==============
-  private val random: Random = new Random(classOf[GraphFrame].getName.##)
-
-  /**
-   * Controls broadcast threshold in skewed joins.
-   * Use normal joins for vertices with degrees less than the threshold,
-   * and broadcast joins otherwise.
-   * The default value is 1000000.
-   * If we have less than 100 billion edges, this would collect at most
-   * 2e11 / 1000000 = 200000 hubs, which could be handled by the driver.
-   */
-  private[this] var _broadcastThreshold: Int = 1000000
-
-  /**
-   * Create a new [[GraphFrame]] from an edge `DataFrame`.
-   * The resulting [[GraphFrame]] will have [[GraphFrame.vertices]] with a single "id" column.
-   *
-   * Note: The [[GraphFrame.vertices]] DataFrame will be persisted at level
-   * `StorageLevel.MEMORY_AND_DISK`.
-   *
-   * @param e Edge DataFrame.  This must include columns "src" and "dst" containing source and
-   *          destination vertex IDs.  All other columns are treated as edge attributes.
-   * @return New [[GraphFrame]] instance
-   * @group conversions
-   */
-  def fromEdges(e: DataFrame): GraphFrame = {
-    val srcs = e.select(e("src").as("id"))
-    val dsts = e.select(e("dst").as("id"))
-    val v = srcs.unionAll(dsts).distinct
-    v.persist(StorageLevel.MEMORY_AND_DISK)
-    apply(v, e)
-  }
-
-  /**
-   * Create a new [[GraphFrame]] from vertex and edge `DataFrame`s.
-   *
-   * @param vertices Vertex DataFrame.  This must include a column "id" containing unique vertex IDs.
-   *                 All other columns are treated as vertex attributes.
-   * @param edges    Edge DataFrame.  This must include columns "src" and "dst" containing source and
-   *                 destination vertex IDs.  All other columns are treated as edge attributes.
-   * @return New [[GraphFrame]] instance
-   */
-  def apply(vertices: DataFrame, edges: DataFrame): GraphFrame = {
-    require(
-      vertices.columns.contains(ID),
-      s"Vertex ID column '$ID' missing from vertex DataFrame, which has columns: "
-        + vertices.columns.mkString(","))
-    require(
-      edges.columns.contains(SRC),
-      s"Source vertex ID column '$SRC' missing from edge DataFrame, which has columns: "
-        + edges.columns.mkString(","))
-    require(
-      edges.columns.contains(DST),
-      s"Destination vertex ID column '$DST' missing from edge DataFrame, which has columns: "
-        + edges.columns.mkString(","))
-
-    new GraphFrame(vertices, edges)
-  }
-
-  /**
-   * Converts a GraphX `Graph` instance into a [[GraphFrame]].
-   *
-   * This converts each `org.apache.spark.rdd.RDD` in the `Graph` to a `DataFrame` using
-   * schema inference.
-   *
-   * Vertex ID column names will be converted to "id" for the vertex DataFrame,
-   * and to "src" and "dst" for the edge DataFrame.
-   *
-   * @group conversions
-   */
-  // TODO: Add version which takes explicit schemas.
-  def fromGraphX[VD: TypeTag, ED: TypeTag](graph: Graph[VD, ED]): GraphFrame = {
-    val sqlContext = SQLContext.getOrCreate(graph.vertices.context)
-    val vv = sqlContext.createDataFrame(graph.vertices).toDF(ID, ATTR)
-    val ee = sqlContext.createDataFrame(graph.edges).toDF(SRC, DST, ATTR)
-    GraphFrame(vv, ee)
-  }
-
-  /**
-   * Given:
-   *  - a GraphFrame `originalGraph`
-   *  - a GraphX graph derived from the GraphFrame using [[GraphFrame.toGraphX]]
-   * this method merges attributes from the GraphX graph into the original GraphFrame.
-   *
-   * This method is useful for doing computations using the GraphX API and then merging the results
-   * with a GraphFrame.  For example, given:
-   *  - GraphFrame `originalGraph`
-   *  - GraphX Graph[String, Int] `graph` with a String vertex attribute we want to call "category"
-   * and an Int edge attribute we want to call "count"
-   * We can call `fromGraphX(originalGraph, graph, Seq("category"), Seq("count"))` to produce
-   * a new GraphFrame. The new GraphFrame will be an augmented version of `originalGraph`,
-   * with new [[GraphFrame.vertices]] column "category" and new [[GraphFrame.edges]] column
-   * "count" added.
-   *
-   * See [[org.graphframes.examples.BeliefPropagation]] for example usage.
-   *
-   * @param originalGraph Original GraphFrame used to compute the GraphX graph.
-   * @param graph         GraphX graph. Vertex and edge attributes, if any, will be merged into
-   *                      the original graph as new columns.  If the attributes are `Product` types
-   *                      such as tuples, then each element of the `Product` will be put in a separate
-   *               column.  If the attributes are other types, then the entire GraphX attribute
-   *                      will become a single new column.
-   * @param vertexNames   Column name(s) for vertex attributes in the GraphX graph.
-   *                      If there is no vertex attribute, this should be empty.
-   *                      If there is a singleton attribute, this should have a single column name.
-   *                      If the attribute is a `Product` type, this should be a list of names
-   *                      matching the order of the attribute elements.
-   * @param edgeNames     Column name(s) for edge attributes in the GraphX graph.
-   *                      If there is no edge attribute, this should be empty.
-   *                      If there is a singleton attribute, this should have a single column name.
-   *                      If the attribute is a `Product` type, this should be a list of names
-   *                      matching the order of the attribute elements.
-   * @tparam V the type of the vertex data
-   * @tparam E the type of the edge data
-   * @return original graph augmented with vertex and column attributes from the GraphX graph
-   * @group conversions
-   */
-  def fromGraphX[V: TypeTag, E: TypeTag](
-      originalGraph: GraphFrame,
-      graph: Graph[V, E],
-      vertexNames: Seq[String] = Nil,
-      edgeNames: Seq[String] = Nil): GraphFrame = {
-    GraphXConversions.fromGraphX[V, E](originalGraph, graph, vertexNames, edgeNames)
-  }
 
   /**
    * Implements `a.join(b, joinCol)`, handling skew in the join keys.
-   *
-   * @param a         DataFrame which may have multiple rows with the same key in `joinCol`
-   * @param b         DataFrame which has exactly 1 row for every key in `a.joinCol`.
-   * @param joinCol   Name of column on which to do join
-   * @param hubs      Set of join keys which are high-degree (skewed)
-   * @param logPrefix Prefix for logging, e.g., name of algorithm doing the join
-   * @return `a.join(b, joinCol)`
-   * @tparam T DataType for join key
+   * @param a  DataFrame which may have multiple rows with the same key in `joinCol`
+   * @param b  DataFrame which has exactly 1 row for every key in `a.joinCol`.
+   * @param joinCol  Name of column on which to do join
+   * @param hubs  Set of join keys which are high-degree (skewed)
+   * @param logPrefix  Prefix for logging, e.g., name of algorithm doing the join
+   * @return  `a.join(b, joinCol)`
+   * @tparam T  DataType for join key
    */
-  private[graphframes] def skewedJoin[T: TypeTag](
+  private[graphframes] def skewedJoin[T : TypeTag](
       a: DataFrame,
       b: DataFrame,
       joinCol: String,
@@ -744,17 +555,168 @@ object GraphFrame extends Serializable with Logging {
       val isHub = udf { id: T =>
         hubs.contains(id)
       }
-      val hashJoined = a
-        .filter(!isHub(col(joinCol)))
+      val hashJoined = a.filter(!isHub(col(joinCol)))
         .join(b.filter(!isHub(col(joinCol))), joinCol)
-      val broadcastJoined = a
-        .filter(isHub(col(joinCol)))
+      val broadcastJoined = a.filter(isHub(col(joinCol)))
         .join(broadcast(b.filter(isHub(col(joinCol)))), joinCol)
       hashJoined.unionAll(broadcastJoined)
     }
   }
 
-  // ========== Motif finding ==========
+  /** Column name for vertex IDs in [[GraphFrame.vertices]] */
+  val ID: String = "id"
+
+  /**
+   * Column name for source vertices of edges.
+   *  - In [[GraphFrame.edges]], this is a column of vertex IDs.
+   *  - In [[GraphFrame.triplets]], this is a column of vertices with schema matching
+   *    [[GraphFrame.vertices]].
+   */
+  val SRC: String = "src"
+
+  /**
+   * Column name for destination vertices of edges.
+   *  - In [[GraphFrame.edges]], this is a column of vertex IDs.
+   *  - In [[GraphFrame.triplets]], this is a column of vertices with schema matching
+   *    [[GraphFrame.vertices]].
+   */
+  val DST: String = "dst"
+
+  /**
+   * Column name for edge in [[GraphFrame.triplets]].  In [[GraphFrame.triplets]],
+   * this is a column of edges with schema matching [[GraphFrame.edges]].
+   */
+  val EDGE: String = "edge"
+
+  // ============================ Constructors and converters =================================
+
+  /**
+   * Create a new [[GraphFrame]] from vertex and edge `DataFrame`s.
+   *
+   * @param vertices  Vertex DataFrame.  This must include a column "id" containing unique vertex IDs.
+   *           All other columns are treated as vertex attributes.
+   * @param edges  Edge DataFrame.  This must include columns "src" and "dst" containing source and
+   *           destination vertex IDs.  All other columns are treated as edge attributes.
+   * @return  New [[GraphFrame]] instance
+   */
+  def apply(vertices: DataFrame, edges: DataFrame): GraphFrame = {
+    require(vertices.columns.contains(ID),
+      s"Vertex ID column '$ID' missing from vertex DataFrame, which has columns: "
+        + vertices.columns.mkString(","))
+    require(edges.columns.contains(SRC),
+      s"Source vertex ID column '$SRC' missing from edge DataFrame, which has columns: "
+        + edges.columns.mkString(","))
+    require(edges.columns.contains(DST),
+      s"Destination vertex ID column '$DST' missing from edge DataFrame, which has columns: "
+        + edges.columns.mkString(","))
+
+    new GraphFrame(vertices, edges)
+  }
+
+  /**
+   * Create a new [[GraphFrame]] from an edge `DataFrame`.
+   * The resulting [[GraphFrame]] will have [[GraphFrame.vertices]] with a single "id" column.
+   *
+   * Note: The [[GraphFrame.vertices]] DataFrame will be persisted at level
+   *       `StorageLevel.MEMORY_AND_DISK`.
+   * @param e  Edge DataFrame.  This must include columns "src" and "dst" containing source and
+   *           destination vertex IDs.  All other columns are treated as edge attributes.
+   * @return  New [[GraphFrame]] instance
+   *
+   * @group conversions
+   */
+  def fromEdges(e: DataFrame): GraphFrame = {
+    val srcs = e.select(e("src").as("id"))
+    val dsts = e.select(e("dst").as("id"))
+    val v = srcs.unionAll(dsts).distinct
+    v.persist(StorageLevel.MEMORY_AND_DISK)
+    apply(v, e)
+  }
+
+  /**
+   * Converts a GraphX `Graph` instance into a [[GraphFrame]].
+   *
+   * This converts each `org.apache.spark.rdd.RDD` in the `Graph` to a `DataFrame` using
+   * schema inference.
+   *
+   * Vertex ID column names will be converted to "id" for the vertex DataFrame,
+   * and to "src" and "dst" for the edge DataFrame.
+   *
+   * @group conversions
+   */
+  // TODO: Add version which takes explicit schemas.
+  def fromGraphX[VD : TypeTag, ED : TypeTag](graph: Graph[VD, ED]): GraphFrame = {
+    val sqlContext = SQLContext.getOrCreate(graph.vertices.context)
+    val vv = sqlContext.createDataFrame(graph.vertices).toDF(ID, ATTR)
+    val ee = sqlContext.createDataFrame(graph.edges).toDF(SRC, DST, ATTR)
+    GraphFrame(vv, ee)
+  }
+
+
+  /**
+   * Given:
+   *  - a GraphFrame `originalGraph`
+   *  - a GraphX graph derived from the GraphFrame using [[GraphFrame.toGraphX]]
+   * this method merges attributes from the GraphX graph into the original GraphFrame.
+   *
+   * This method is useful for doing computations using the GraphX API and then merging the results
+   * with a GraphFrame.  For example, given:
+   *  - GraphFrame `originalGraph`
+   *  - GraphX Graph[String, Int] `graph` with a String vertex attribute we want to call "category"
+   *    and an Int edge attribute we want to call "count"
+   * We can call `fromGraphX(originalGraph, graph, Seq("category"), Seq("count"))` to produce
+   * a new GraphFrame. The new GraphFrame will be an augmented version of `originalGraph`,
+   * with new [[GraphFrame.vertices]] column "category" and new [[GraphFrame.edges]] column
+   * "count" added.
+   *
+   * See [[org.graphframes.examples.BeliefPropagation]] for example usage.
+   *
+   * @param originalGraph  Original GraphFrame used to compute the GraphX graph.
+   * @param graph  GraphX graph. Vertex and edge attributes, if any, will be merged into
+   *               the original graph as new columns.  If the attributes are `Product` types
+   *               such as tuples, then each element of the `Product` will be put in a separate
+   *               column.  If the attributes are other types, then the entire GraphX attribute
+   *               will become a single new column.
+   * @param vertexNames  Column name(s) for vertex attributes in the GraphX graph.
+   *                     If there is no vertex attribute, this should be empty.
+   *                     If there is a singleton attribute, this should have a single column name.
+   *                     If the attribute is a `Product` type, this should be a list of names
+   *                     matching the order of the attribute elements.
+   * @param edgeNames  Column name(s) for edge attributes in the GraphX graph.
+   *                     If there is no edge attribute, this should be empty.
+   *                     If there is a singleton attribute, this should have a single column name.
+   *                     If the attribute is a `Product` type, this should be a list of names
+   *                     matching the order of the attribute elements.
+   * @tparam V the type of the vertex data
+   * @tparam E the type of the edge data
+   * @return original graph augmented with vertex and column attributes from the GraphX graph
+   *
+   * @group conversions
+   */
+  def fromGraphX[V : TypeTag, E : TypeTag](
+      originalGraph: GraphFrame,
+      graph: Graph[V, E],
+      vertexNames: Seq[String] = Nil,
+      edgeNames: Seq[String] = Nil): GraphFrame = {
+    GraphXConversions.fromGraphX[V, E](originalGraph, graph, vertexNames, edgeNames)
+  }
+
+
+  // ============== Private constants ==============
+
+  /** Default name for attribute columns when converting from GraphX [[Graph]] format */
+  private[graphframes] val ATTR: String = "attr"
+
+  /**
+   * The integral id that is used as a surrogate id when using graphX implementation
+   */
+  private[graphframes] val LONG_ID: String = "new_id"
+
+  private[graphframes] val LONG_SRC: String = "new_src"
+  private[graphframes] val LONG_DST: String = "new_dst"
+  private[graphframes] val GX_ATTR: String = "graphx_attr"
+
+
 
   /** Helper for using [col].* in Spark 1.4.  Returns sequence of [col].[field] for all fields */
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
@@ -762,24 +724,25 @@ object GraphFrame extends Serializable with Logging {
       case s: StructType =>
         s.fieldNames.map(f => col + "." + f)
       case other =>
-        throw new RuntimeException(
-          s"Unknown error in GraphFrame. Expected column $col to be" +
-            s" StructType, but found type: $other")
+        throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
+          s" StructType, but found type: $other")
     }
   }
 
   /** Nest all columns within a single StructType column with the given name */
   private[graphframes] def nestAsCol(df: DataFrame, name: String): Column = {
-    struct(df.columns.map(c => df(c)): _*).as(name)
+    struct(df.columns.map(c => df(c)) :_*).as(name)
   }
 
+  // ========== Motif finding ==========
+
+  private val random: Random = new Random(classOf[GraphFrame].getName.##)
+
   private def prefixWithName(name: String, col: String): String = name + "." + col
-
   private def vId(name: String): String = prefixWithName(name, ID)
-
   private def eSrcId(name: String): String = prefixWithName(name, SRC)
-
   private def eDstId(name: String): String = prefixWithName(name, DST)
+
 
   private def maybeJoin(aOpt: Option[DataFrame], b: DataFrame): DataFrame = {
     aOpt match {
@@ -798,6 +761,7 @@ object GraphFrame extends Serializable with Logging {
     }
   }
 
+
   /** Indicate whether a named vertex has been seen in any of the given patterns */
   private def seen(v: NamedVertex, patterns: Seq[Pattern]) = patterns.exists(p => seen1(v, p))
 
@@ -815,13 +779,14 @@ object GraphFrame extends Serializable with Logging {
       false
   }
 
+
   /**
    * Augment the given DataFrame based on a pattern.
    *
-   * @param prevPatterns Patterns which have contributed to the given DataFrame
-   * @param prev         Given DataFrame
-   * @param pattern      Pattern to search for
-   * @return DataFrame augmented with the current search pattern
+   * @param prevPatterns  Patterns which have contributed to the given DataFrame
+   * @param prev  Given DataFrame
+   * @param pattern  Pattern to search for
+   * @return  DataFrame augmented with the current search pattern
    */
   private def findIncremental(
       gf: GraphFrame,
@@ -830,7 +795,6 @@ object GraphFrame extends Serializable with Logging {
       prevNames: Seq[String],
       pattern: Pattern): (Option[DataFrame], Seq[String]) = {
     def nestE(name: String): DataFrame = gf.edges.select(nestAsCol(gf.edges, name))
-
     def nestV(name: String): DataFrame = gf.vertices.select(nestAsCol(gf.vertices, name))
 
     pattern match {
@@ -853,96 +817,86 @@ object GraphFrame extends Serializable with Logging {
       case NamedEdge(name, AnonymousVertex, dst @ NamedVertex(dstName)) =>
         if (seen(dst, prevPatterns)) {
           val eRen = nestE(name)
-          (
-            Some(maybeJoin(prev, eRen, prev => eRen(eDstId(name)) === prev(vId(dstName)))),
+          (Some(maybeJoin(prev, eRen, prev => eRen(eDstId(name)) === prev(vId(dstName)))),
             prevNames :+ name)
         } else {
           val eRen = nestE(name)
           val dstV = nestV(dstName)
-          (
-            Some(
-              maybeJoin(prev, eRen)
-                .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)), "left_outer")),
+          (Some(maybeJoin(prev, eRen)
+            .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)), "left_outer")),
             prevNames :+ name :+ dstName)
         }
 
       case NamedEdge(name, src @ NamedVertex(srcName), AnonymousVertex) =>
         if (seen(src, prevPatterns)) {
           val eRen = nestE(name)
-          (
-            Some(maybeJoin(prev, eRen, prev => eRen(eSrcId(name)) === prev(vId(srcName)))),
+          (Some(maybeJoin(prev, eRen, prev => eRen(eSrcId(name)) === prev(vId(srcName)))),
             prevNames :+ name)
         } else {
           val eRen = nestE(name)
           val srcV = nestV(srcName)
-          (
-            Some(
-              maybeJoin(prev, eRen)
-                .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))),
-            prevNames :+ srcName :+ name)
+          (Some(maybeJoin(prev, eRen)
+            .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))),
+             prevNames :+ srcName :+ name)
         }
 
       case NamedEdge(name, src @ NamedVertex(srcName), dst @ NamedVertex(dstName)) =>
         (seen(src, prevPatterns), seen(dst, prevPatterns)) match {
           case (true, true) =>
             val eRen = nestE(name)
-            (
-              Some(
-                maybeJoin(
-                  prev,
-                  eRen,
-                  prev =>
-                    eRen(eSrcId(name)) === prev(vId(srcName)) && eRen(eDstId(name)) === prev(
-                      vId(dstName)))),
+            (Some(maybeJoin(prev, eRen, prev =>
+              eRen(eSrcId(name)) === prev(vId(srcName)) && eRen(eDstId(name)) === prev(vId(dstName)))),
               prevNames :+ name)
 
           case (true, false) =>
             val eRen = nestE(name)
             val dstV = nestV(dstName)
-            (
-              Some(
-                maybeJoin(prev, eRen, prev => eRen(eSrcId(name)) === prev(vId(srcName)))
-                  .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
+            (Some(maybeJoin(prev, eRen, prev => eRen(eSrcId(name)) === prev(vId(srcName)))
+              .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
               prevNames :+ name :+ dstName)
 
           case (false, true) =>
             val eRen = nestE(name)
             val srcV = nestV(srcName)
-            (
-              Some(
-                maybeJoin(prev, eRen, prev => eRen(eDstId(name)) === prev(vId(dstName)))
-                  .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))),
+            (Some(maybeJoin(prev, eRen, prev => eRen(eDstId(name)) === prev(vId(dstName)))
+              .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))),
               prevNames :+ srcName :+ name)
 
           case (false, false) =>
             val eRen = nestE(name)
             val srcV = nestV(srcName)
             val dstV = nestV(dstName)
-            (
-              Some(
-                maybeJoin(prev, eRen)
-                  .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))
-                  .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
+            (Some(maybeJoin(prev, eRen)
+              .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))
+              .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
               prevNames :+ srcName :+ name :+ dstName)
           // TODO: expose the plans from joining these in the opposite order
         }
 
       case AnonymousEdge(src, dst) =>
         val tmpName = "__tmp" + random.nextLong.toString
-        val (df, names) =
-          findIncremental(gf, prevPatterns, prev, prevNames, NamedEdge(tmpName, src, dst))
+        val (df, names) = findIncremental(gf, prevPatterns, prev, prevNames, NamedEdge(tmpName, src, dst))
         (df.map(_.drop(tmpName)), names.filter(_ != tmpName))
 
-      case Negation(edge) =>
-        prev match {
-          case Some(p) =>
-            val (df, names) = findIncremental(gf, prevPatterns, Some(p), prevNames, edge)
-            (df.map(result => p.except(result)), names)
-          case None =>
-            throw new InvalidPatternException
-        }
+      case Negation(edge) => prev match {
+        case Some(p) =>
+          val (df, names) = findIncremental(gf, prevPatterns, Some(p), prevNames, edge)
+          (df.map(result => p.except(result)), names)
+        case None =>
+          throw new InvalidPatternException
+      }
     }
   }
+
+  /**
+   * Controls broadcast threshold in skewed joins.
+   * Use normal joins for vertices with degrees less than the threshold,
+   * and broadcast joins otherwise.
+   * The default value is 1000000.
+   * If we have less than 100 billion edges, this would collect at most
+   * 2e11 / 1000000 = 200000 hubs, which could be handled by the driver.
+   */
+  private[this] var _broadcastThreshold: Int = 1000000
 
   private[graphframes] def broadcastThreshold: Int = _broadcastThreshold
 

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -18,7 +18,6 @@
 package org.graphframes.lib
 
 import org.apache.spark.graphx.{lib => graphxlib}
-
 import org.graphframes.{GraphFrame, Logging}
 
 class ParallelPersonalizedPageRank private[graphframes] (
@@ -75,7 +74,7 @@ private object ParallelPersonalizedPageRank {
     resetProb: Double = 0.15,
     sources: Array[Any]): GraphFrame = {
     val longSrcIds = sources.map(GraphXConversions.integralId(graph, _))
-    val gx = graphxlib.PageRank.runParallelPersonalizedPageRank(
+    val gx = graphxlib.GraphXHelpers.runParallelPersonalizedPageRank(
       graph.cachedTopologyGraphX, numIter, resetProb, longSrcIds)
     GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(PAGERANK), edgeNames = Seq(WEIGHT))
   }

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -23,10 +23,11 @@ import org.graphframes.{GraphFrame, Logging}
 /**
  * Parallel Personalized PageRank algorithm implementation.
  *
- * The first implementation uses the standalone [[GraphFrame]] interface and
+ * This implementation uses the standalone [[GraphFrame]] interface and
  * runs personalized PageRank in parallel for a fixed number of iterations.
- * This can be run by setting `numIter`.
+ * This can be run by setting `maxIter`.
  * The source vertex Ids are set in `sourceIds`.
+ * A simple local implementation of this algorithm is as follows.
  * {{{
  * var oldPR = Array.fill(n)( 1.0 )
  * val PR = (0 until n).map(i => if sourceIds.contains(i) alpha else 0.0)
@@ -47,7 +48,7 @@ import org.graphframes.{GraphFrame, Logging}
  * greater than 1.
  *
  * The resulting vertices DataFrame contains one additional column:
- *  - pageranks (`DoubleType`): the pageranks of this vertex from all input source vertices
+ *  - pageranks (`VectorType`): the pageranks of this vertex from all input source vertices
  *
  * The resulting edges DataFrame contains one additional column:
  *  - weight (`DoubleType`): the normalized weight of this edge after running PageRank
@@ -94,13 +95,13 @@ private object ParallelPersonalizedPageRank {
   /**
    * Run Personalized PageRank for a fixed number of iterations, for a
    * set of starting nodes in parallel. Returns a graph with vertex attributes
-   * containing the pagerank relative to all starting nodes (as a vector) and
+   * containing the pageranks relative to all starting nodes (as a vector) and
    * edge attributes the normalized edge weight
    *
    * @param graph     The graph on which to compute personalized pagerank
-   * @param numIter   The number of iterations to run
+   * @param maxIter   The number of iterations to run
    * @param resetProb The random reset probability
-   * @param sources   The list of sources to compute personalized pagerank from
+   * @param sourceIds   The list of sources to compute personalized pagerank from
    * @return the graph with vertex attributes
    *         containing the pageranks relative to all starting nodes as a vector and
    *         edge attributes the normalized edge weight

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -21,11 +21,11 @@ import org.apache.spark.graphx.{lib => graphxlib}
 import org.graphframes.{GraphFrame, Logging}
 
 class ParallelPersonalizedPageRank private[graphframes] (
-  private val graph: GraphFrame) extends Arguments {
+      private val graph: GraphFrame) extends Arguments {
 
   private var resetProb: Option[Double] = Some(0.15)
   private var numIter: Option[Int] = Some(10)
-  private var srcIds : Array[Any] = Array()
+  private var srcIds: Array[Any] = Array()
 
   /** Source vertex for a Personalized Page Rank (optional) */
   def sources(values: Array[Any]): this.type = {
@@ -52,38 +52,36 @@ class ParallelPersonalizedPageRank private[graphframes] (
 
 private object ParallelPersonalizedPageRank {
 
-  /**
-    * Run Personalized PageRank for a fixed number of iterations, for a
-    * set of starting nodes in parallel. Returns a graph with vertex attributes
-    * containing the pagerank relative to all starting nodes (as a sparse vector) and
-    * edge attributes the normalized edge weight
-    *
-    *
-    * @param graph The graph on which to compute personalized pagerank
-    * @param numIter The number of iterations to run
-    * @param resetProb The random reset probability
-    * @param sources The list of sources to compute personalized pagerank from
-    * @return the graph with vertex attributes
-    *         containing the pagerank relative to all starting nodes (as a sparse vector
-    *         indexed by the position of nodes in the sources list) and
-    *         edge attributes the normalized edge weight
-    */
-  def run(
-    graph: GraphFrame,
-    numIter: Int,
-    resetProb: Double = 0.15,
-    sources: Array[Any]): GraphFrame = {
-    val longSrcIds = sources.map(GraphXConversions.integralId(graph, _))
-    val gx = graphxlib.GraphXHelpers.runParallelPersonalizedPageRank(
-      graph.cachedTopologyGraphX, numIter, resetProb, longSrcIds)
-    GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(PAGERANK), edgeNames = Seq(WEIGHT))
-  }
-
   /** Default name for the pagerank column. */
   private val PAGERANK = "pagerank"
 
   /** Default name for the weight column. */
   private val WEIGHT = "weight"
+
+  /**
+   * Run Personalized PageRank for a fixed number of iterations, for a
+   * set of starting nodes in parallel. Returns a graph with vertex attributes
+   * containing the pagerank relative to all starting nodes (as a sparse vector) and
+   * edge attributes the normalized edge weight
+   *
+   * @param graph     The graph on which to compute personalized pagerank
+   * @param numIter   The number of iterations to run
+   * @param resetProb The random reset probability
+   * @param sources   The list of sources to compute personalized pagerank from
+   * @return the graph with vertex attributes
+   *         containing the pagerank relative to all starting nodes (as a sparse vector
+   *         indexed by the position of nodes in the sources list) and
+   *         edge attributes the normalized edge weight
+   */
+  def run(
+      graph: GraphFrame, 
+      numIter: Int, 
+      resetProb: Double, 
+      sources: Array[Any]): GraphFrame = {
+
+    val longSrcIds = sources.map(GraphXConversions.integralId(graph, _))
+    val gx = graphxlib.GraphXHelpers.runParallelPersonalizedPageRank(
+      graph.cachedTopologyGraphX, numIter, resetProb, longSrcIds)
+    GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(PAGERANK), edgeNames = Seq(WEIGHT))
+  }
 }
-
-

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -26,13 +26,15 @@ import org.graphframes.{GraphFrame, Logging}
  * The first implementation uses the standalone [[GraphFrame]] interface and
  * runs personalized PageRank in parallel for a fixed number of iterations.
  * This can be run by setting `numIter`.
+ * The source vertex Ids are set in `sourceIds`.
  * {{{
- * var PR = Array.fill(n)( 1.0 )
- * val oldPR = Array.fill(n)( 1.0 )
+ * var oldPR = Array.fill(n)( 1.0 )
+ * val PR = (0 until n).map(i => if sourceIds.contains(i) alpha else 0.0)
  * for( iter <- 0 until maxIter ) {
  *   swap(oldPR, PR)
  *   for( i <- 0 until n ) {
- *     PR[i] = alpha + (1 - alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+ *     PR[i] = (1 - alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+ *     if (sourceIds.contains(i)) PR[i] += alpha
  *   }
  * }
  * }}}

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -24,7 +24,7 @@ class ParallelPersonalizedPageRank private[graphframes] (
       private val graph: GraphFrame) extends Arguments {
 
   private var resetProb: Option[Double] = Some(0.15)
-  private var numIter: Option[Int] = Some(10)
+  private var numIter: Option[Int] = None
   private var srcIds: Array[Any] = Array()
 
   /** Source vertex for a Personalized Page Rank (optional) */
@@ -46,6 +46,8 @@ class ParallelPersonalizedPageRank private[graphframes] (
   }
 
   def run(): GraphFrame = {
+    require(numIter != None, s"Number of iterations must be provided")
+    require(srcIds.nonEmpty, s"Source vertices Ids must be provided")
     ParallelPersonalizedPageRank.run(graph, numIter.get, resetProb.get, srcIds)
   }
 }
@@ -69,8 +71,7 @@ private object ParallelPersonalizedPageRank {
    * @param resetProb The random reset probability
    * @param sources   The list of sources to compute personalized pagerank from
    * @return the graph with vertex attributes
-   *         containing the pagerank relative to all starting nodes (as a sparse vector
-   *         indexed by the position of nodes in the sources list) and
+   *         containing the pagerank relative to all starting nodes as a vector
    *         edge attributes the normalized edge weight
    */
   def run(

--- a/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
+++ b/src/main/scala/org/graphframes/lib/ParallelPersonalizedPageRank.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graphframes.lib
+
+import org.apache.spark.graphx.{lib => graphxlib}
+
+import org.graphframes.{GraphFrame, Logging}
+
+class ParallelPersonalizedPageRank private[graphframes] (
+  private val graph: GraphFrame) extends Arguments {
+
+  private var resetProb: Option[Double] = Some(0.15)
+  private var numIter: Option[Int] = Some(10)
+  private var srcIds : Array[Any] = Array()
+
+  /** Source vertex for a Personalized Page Rank (optional) */
+  def sources(values: Array[Any]): this.type = {
+    this.srcIds = values
+    this
+  }
+
+  /** Reset probability "alpha" */
+  def resetProbability(value: Double): this.type = {
+    resetProb = Some(value)
+    this
+  }
+
+  /** Number of iterations to run */
+  def numIter(value: Int): this.type = {
+    this.numIter = Some(value)
+    this
+  }
+
+  def run(): GraphFrame = {
+    ParallelPersonalizedPageRank.run(graph, numIter.get, resetProb.get, srcIds)
+  }
+}
+
+private object ParallelPersonalizedPageRank {
+
+  /**
+    * Run Personalized PageRank for a fixed number of iterations, for a
+    * set of starting nodes in parallel. Returns a graph with vertex attributes
+    * containing the pagerank relative to all starting nodes (as a sparse vector) and
+    * edge attributes the normalized edge weight
+    *
+    *
+    * @param graph The graph on which to compute personalized pagerank
+    * @param numIter The number of iterations to run
+    * @param resetProb The random reset probability
+    * @param sources The list of sources to compute personalized pagerank from
+    * @return the graph with vertex attributes
+    *         containing the pagerank relative to all starting nodes (as a sparse vector
+    *         indexed by the position of nodes in the sources list) and
+    *         edge attributes the normalized edge weight
+    */
+  def run(
+    graph: GraphFrame,
+    numIter: Int,
+    resetProb: Double = 0.15,
+    sources: Array[Any]): GraphFrame = {
+    val longSrcIds = sources.map(GraphXConversions.integralId(graph, _))
+    val gx = graphxlib.PageRank.runParallelPersonalizedPageRank(
+      graph.cachedTopologyGraphX, numIter, resetProb, longSrcIds)
+    GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(PAGERANK), edgeNames = Seq(WEIGHT))
+  }
+
+  /** Default name for the pagerank column. */
+  private val PAGERANK = "pagerank"
+
+  /** Default name for the weight column. */
+  private val WEIGHT = "weight"
+}
+
+

--- a/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -29,8 +29,8 @@ object GraphXHelpers {
       graph: Graph[VD, ED],
       numIter: Int, 
       resetProb: Double,
-      sources: Array[VertexId]): Graph[Vector, Double] = {
-      throw new NotImplementedError(
-        "parallel personalized PageRank only supported in Apache Spark version 2.1+")
+      sourceIds: Array[VertexId]): Graph[Vector, Double] = {
+    throw new NotImplementedError(
+      "parallel personalized PageRank only supported in Apache Spark version 2.1+")
   }
 }

--- a/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx.lib
+
+import scala.reflect.ClassTag
+
+import breeze.linalg.{Vector => BV}
+
+import org.apache.spark.graphx._
+import org.apache.spark.mllib.linalg.Vector
+
+object GraphXHelpers {
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
+    numIter: Int, resetProb: Double = 0.15,
+    sources: Array[VertexId]): Graph[Vector, Double] = {
+    throw new NotImplementedError("parallel personalized PageRank only supported in version 2.1+")
+  }
+}

--- a/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -26,8 +26,9 @@ import org.apache.spark.mllib.linalg.Vector
 
 object GraphXHelpers {
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-    numIter: Int, resetProb: Double = 0.15,
-    sources: Array[VertexId]): Graph[Vector, Double] = {
-    throw new NotImplementedError("parallel personalized PageRank only supported in version 2.1+")
+      numIter: Int, resetProb: Double = 0.15,
+      sources: Array[VertexId]): Graph[Vector, Double] = {
+      throw new NotImplementedError(
+        "parallel personalized PageRank only supported in Apache Spark version 2.1+")
   }
 }

--- a/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -25,8 +25,10 @@ import org.apache.spark.graphx._
 import org.apache.spark.mllib.linalg.Vector
 
 object GraphXHelpers {
-  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-      numIter: Int, resetProb: Double,
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag] (
+      graph: Graph[VD, ED],
+      numIter: Int, 
+      resetProb: Double,
       sources: Array[VertexId]): Graph[Vector, Double] = {
       throw new NotImplementedError(
         "parallel personalized PageRank only supported in Apache Spark version 2.1+")

--- a/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -26,7 +26,7 @@ import org.apache.spark.mllib.linalg.Vector
 
 object GraphXHelpers {
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-      numIter: Int, resetProb: Double = 0.15,
+      numIter: Int, resetProb: Double,
       sources: Array[VertexId]): Graph[Vector, Double] = {
       throw new NotImplementedError(
         "parallel personalized PageRank only supported in Apache Spark version 2.1+")

--- a/src/main/spark-1.x/org/apache/spark/graphx/ml/MLHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/ml/MLHelpers.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.ml.linalg
+
+import org.apache.spark.annotation.{DeveloperApi, Since}
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types._
+
+// private[spark] class MatrixUDT extends UserDefinedType[Double]
+// private[spark] class VectorUDT extends UserDefinedType[Double]
+
+/**
+ * :: DeveloperApi ::
+ * SQL data types for vectors and matrices.
+ */
+@Since("2.0.0")
+@DeveloperApi
+object SQLDataTypes {
+
+  /** Data type for [[Vector]]. */
+  val VectorType: DataType = NullType
+
+  /** Data type for [[Matrix]]. */
+  val MatrixType: DataType = NullType
+}
+
+sealed trait Vector
+sealed trait Matrix
+/**
+ * A sparse vector represented by an index array and a value array.
+ *
+ * @param size size of the vector.
+ * @param indices index array, assume to be strictly increasing.
+ * @param values value array, must have the same length as the index array.
+ */
+case class SparseVector(
+    size: Int,
+    indices: Array[Int],
+    values: Array[Double]) extends Vector {
+  def numNonzeros: Int = {
+    throw new NotImplementedError("SparseVector type is only supported in Spark 2.0+")
+  }
+}
+

--- a/src/main/spark-1.x/org/apache/spark/graphx/ml/MLHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/graphx/ml/MLHelpers.scala
@@ -17,19 +17,8 @@
 
 package org.apache.spark.ml.linalg
 
-import org.apache.spark.annotation.{DeveloperApi, Since}
-import org.apache.spark.sql.types.DataType
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.types.{DataType, NullType}
 
-// private[spark] class MatrixUDT extends UserDefinedType[Double]
-// private[spark] class VectorUDT extends UserDefinedType[Double]
-
-/**
- * :: DeveloperApi ::
- * SQL data types for vectors and matrices.
- */
-@Since("2.0.0")
-@DeveloperApi
 object SQLDataTypes {
 
   /** Data type for [[Vector]]. */
@@ -39,21 +28,15 @@ object SQLDataTypes {
   val MatrixType: DataType = NullType
 }
 
-sealed trait Vector
-sealed trait Matrix
 /**
- * A sparse vector represented by an index array and a value array.
- *
- * @param size size of the vector.
- * @param indices index array, assume to be strictly increasing.
- * @param values value array, must have the same length as the index array.
+ * This is a shim for the SparseVector type
  */
-case class SparseVector(
-    size: Int,
-    indices: Array[Int],
-    values: Array[Double]) extends Vector {
+case class SparseVector(size: Int, indices: Array[Int], values: Array[Double]) {
   def numNonzeros: Int = {
-    throw new NotImplementedError("SparseVector type is only supported in Spark 2.0+")
+    throw new NotImplementedError(
+      """
+        |This error should never happen;
+        |if it does, please file a bug report on the GraphFrames Github page.
+      """.stripMargin)
   }
 }
-

--- a/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx.lib
+
+import scala.reflect.ClassTag
+
+import breeze.linalg.{Vector => BV}
+
+import org.apache.spark.graphx._
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+
+object GraphXHelpers {
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
+    numIter: Int, resetProb: Double = 0.15,
+    sources: Array[VertexId]): Graph[Vector, Double] = {
+    throw new NotImplementedError("parallel personalized PageRank only supported in version 2.1+")
+  }
+}

--- a/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -29,8 +29,8 @@ object GraphXHelpers {
       graph: Graph[VD, ED],
       numIter: Int, 
       resetProb: Double,
-      sources: Array[VertexId]): Graph[Vector, Double] = {
-      throw new NotImplementedError(
-        "parallel personalized PageRank only supported in Apache Spark version 2.1+")
+      sourceIds: Array[VertexId]): Graph[Vector, Double] = {
+    throw new NotImplementedError(
+      "parallel personalized PageRank only supported in Apache Spark version 2.1+")
   }
 }

--- a/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -26,7 +26,7 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 object GraphXHelpers {
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-      numIter: Int, resetProb: Double = 0.15,
+      numIter: Int, resetProb: Double,
       sources: Array[VertexId]): Graph[Vector, Double] = {
       throw new NotImplementedError(
         "parallel personalized PageRank only supported in Apache Spark version 2.1+")

--- a/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -26,8 +26,9 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 object GraphXHelpers {
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-    numIter: Int, resetProb: Double = 0.15,
-    sources: Array[VertexId]): Graph[Vector, Double] = {
-    throw new NotImplementedError("parallel personalized PageRank only supported in version 2.1+")
+      numIter: Int, resetProb: Double = 0.15,
+      sources: Array[VertexId]): Graph[Vector, Double] = {
+      throw new NotImplementedError(
+        "parallel personalized PageRank only supported in Apache Spark version 2.1+")
   }
 }

--- a/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -25,8 +25,10 @@ import org.apache.spark.graphx._
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 object GraphXHelpers {
-  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-      numIter: Int, resetProb: Double,
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag] (
+      graph: Graph[VD, ED],
+      numIter: Int, 
+      resetProb: Double,
       sources: Array[VertexId]): Graph[Vector, Double] = {
       throw new NotImplementedError(
         "parallel personalized PageRank only supported in Apache Spark version 2.1+")

--- a/src/main/spark-2.0/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/sql/SQLHelpers.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types.{DataType, LongType, StructField, StructType}
+
+object SQLHelpers {
+  def getExpr(col: Column): Expression = col.expr
+
+  def expr(e: String): Column = functions.expr(e)
+
+  /**
+   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
+   * This is a workaround for SPARK-9020 and SPARK-13473.
+   */
+  def zipWithUniqueId(df: DataFrame): DataFrame = {
+    val sqlContext = df.sqlContext
+    val schema = df.schema
+    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
+      Row(row, id)
+    }
+    val outputSchema = StructType(Seq(
+      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
+    sqlContext.createDataFrame(rdd, outputSchema)
+  }
+
+  def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
+    val u = udf(f, returnType)
+    u(arg1)
+  }
+}

--- a/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -30,7 +30,7 @@ object GraphXHelpers {
       graph: Graph[VD, ED],
       numIter: Int, 
       resetProb: Double,
-      sources: Array[VertexId]): Graph[Vector, Double] = {
-    PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
+      sourceIds: Array[VertexId]): Graph[Vector, Double] = {
+    PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sourceIds)
   }
 }

--- a/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -27,7 +27,7 @@ import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 object GraphXHelpers {
   def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-    numIter: Int, resetProb: Double = 0.15,
+    numIter: Int, resetProb: Double,
     sources: Array[VertexId]): Graph[Vector, Double] = {
     PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
   }

--- a/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -26,9 +26,11 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 object GraphXHelpers {
-  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
-    numIter: Int, resetProb: Double,
-    sources: Array[VertexId]): Graph[Vector, Double] = {
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag] (
+      graph: Graph[VD, ED],
+      numIter: Int, 
+      resetProb: Double,
+      sources: Array[VertexId]): Graph[Vector, Double] = {
     PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
   }
 }

--- a/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/graphx/lib/GraphXHelpers.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx.lib
+
+import scala.reflect.ClassTag
+
+import breeze.linalg.{Vector => BV}
+
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+
+object GraphXHelpers {
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED],
+    numIter: Int, resetProb: Double = 0.15,
+    sources: Array[VertexId]): Graph[Vector, Double] = {
+    PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
+  }
+}

--- a/src/test/scala/org/graphframes/GraphFrameTestSparkContext.scala
+++ b/src/test/scala/org/graphframes/GraphFrameTestSparkContext.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.SQLContext
 trait GraphFrameTestSparkContext extends BeforeAndAfterAll { self: Suite =>
   @transient var sc: SparkContext = _
   @transient var sqlContext: SQLContext = _
+  @transient var spVers: Seq[Int] = _
 
   override def beforeAll() {
     super.beforeAll()
@@ -40,6 +41,7 @@ trait GraphFrameTestSparkContext extends BeforeAndAfterAll { self: Suite =>
     val checkpointDir = Files.createTempDirectory(this.getClass.getName).toString
     sc.setCheckpointDir(checkpointDir)
     sqlContext = new SQLContext(sc)
+    spVers = sc.version.split('.').map(_.toInt)
   }
 
   override def afterAll() {

--- a/src/test/scala/org/graphframes/GraphFrameTestSparkContext.scala
+++ b/src/test/scala/org/graphframes/GraphFrameTestSparkContext.scala
@@ -52,7 +52,7 @@ trait GraphFrameTestSparkContext extends BeforeAndAfterAll { self: Suite =>
       .set("spark.sql.shuffle.partitions", "4")  // makes small tests much faster
     sc = new SparkContext(conf)
     val checkpointDir = Files.createTempDirectory(this.getClass.getName).toString
-    sc.setCheckpointDir(checkpointDir)    
+    sc.setCheckpointDir(checkpointDir)
     sqlContext = new SQLContext(sc)
     val (verMajor, verMinor) = majorMinorVersion(sc.version)
     sparkVersionMajor = verMajor

--- a/src/test/scala/org/graphframes/TestUtils.scala
+++ b/src/test/scala/org/graphframes/TestUtils.scala
@@ -2,6 +2,7 @@ package org.graphframes
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.ml.linalg.VectorUDT
 
 import org.graphframes.GraphFrame._
 

--- a/src/test/scala/org/graphframes/TestUtils.scala
+++ b/src/test/scala/org/graphframes/TestUtils.scala
@@ -2,7 +2,6 @@ package org.graphframes
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.ml.linalg.VectorUDT
 
 import org.graphframes.GraphFrame._
 

--- a/src/test/scala/org/graphframes/TestUtils.scala
+++ b/src/test/scala/org/graphframes/TestUtils.scala
@@ -7,6 +7,19 @@ import org.graphframes.GraphFrame._
 
 object TestUtils {
 
+  private[this] val majorMinorRegex = """^(\d+)\.(\d+)(\..*)?$""".r
+
+  /** Extract major/minor version integer pairs from a version string */
+  def majorMinorVersion(sparkVersion: String): (Int, Int) = {
+    majorMinorRegex.findFirstMatchIn(sparkVersion) match {
+      case Some(m) =>
+        (m.group(1).toInt, m.group(2).toInt)
+      case None =>
+        throw new IllegalArgumentException(s"Spark tried to parse '$sparkVersion' as a Spark" +
+          s" version string, but it could not find the major and minor version numbers.")
+    }
+  }
+
   /**
    * Check whether the given schema contains a column of the required data type.
    *

--- a/src/test/scala/org/graphframes/lib/PageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PageRankSuite.scala
@@ -19,8 +19,6 @@ package org.graphframes.lib
 
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
-import org.apache.spark.sql.Row
-import org.apache.spark.ml.linalg.{SQLDataTypes, SparseVector}
 
 import org.graphframes.examples.Graphs
 import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}
@@ -28,11 +26,6 @@ import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}
 class PageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   val n = 100
-
-  private def isLaterVersion(minVer: String): Boolean = {
-    val minVers = minVer.split('.').map(_.toInt)
-    spVers.zip(minVers).forall { case (spV, minV) => spV >= minV }
-  }
 
   test("Star example") {
     val g = Graphs.star(n)
@@ -53,62 +46,4 @@ class PageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(gRank === 0.0,
       s"User g (Gabby) doesn't connect with a. So its pagerank should be 0 but we got $gRank.")
   }
-
-  test("Star example parallel personalized PageRank") {
-    val g = Graphs.star(n)
-    val resetProb = 0.15
-    val numIter = 10
-    val vertexIds: Array[Any] = Array(1L, 2L, 3L)
-
-    lazy val prc = g.parallelPersonalizedPageRank
-      .numIter(numIter)
-      .sources(vertexIds)
-      .resetProbability(resetProb)
-
-    if (isLaterVersion("2.1")) {
-      val pr = prc.run()
-      TestUtils.testSchemaInvariants(g, pr)
-      TestUtils.checkColumnType(pr.vertices.schema, "pagerank", SQLDataTypes.VectorType)
-      TestUtils.checkColumnType(pr.edges.schema, "weight", DataTypes.DoubleType)
-    } else {
-      intercept[NotImplementedError] { prc.run() }
-    }
-  }
-
-  test("friends graph with parallel personalized PageRank") {
-    val g = Graphs.friends
-    val resetProb = 0.15
-    val numIter = 10
-    val vertexIds: Array[Any] = Array("a")
-    lazy val prc = g.parallelPersonalizedPageRank
-      .numIter(numIter)
-      .sources(vertexIds)
-      .resetProbability(resetProb)
-
-    if (isLaterVersion("2.1")) {
-      val pr = prc.run()
-      val prInvalid = pr.vertices
-        .select("pagerank")
-        .collect()
-        .filter { row: Row =>
-          vertexIds.size != row.get(0).asInstanceOf[SparseVector].size
-        }
-      val prInvalidSize = prInvalid.size
-      if (0L != prInvalidSize) {
-        //prInvalid.show(10)
-        assert(false,
-          s"found $prInvalidSize entries with invalid number of returned personalized pagerank vector")
-      }
-
-      val gRank = pr.vertices
-        .filter(col("id") === "g")
-        .select("pagerank")
-        .first().get(0).asInstanceOf[SparseVector]
-      assert(gRank.numNonzeros === 0,
-        s"User g (Gabby) doesn't connect with a. So its pagerank should be 0 but we got ${gRank.numNonzeros}.")
-    } else {
-      intercept[NotImplementedError] { prc.run() }
-    }
-  }
-
 }

--- a/src/test/scala/org/graphframes/lib/PageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PageRankSuite.scala
@@ -19,6 +19,7 @@ package org.graphframes.lib
 
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.Row
 import org.apache.spark.ml.linalg.{SQLDataTypes, SparseVector}
 
 import org.graphframes.examples.Graphs
@@ -88,10 +89,13 @@ class PageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       val pr = prc.run()
       val prInvalid = pr.vertices
         .select("pagerank")
-        .filter(vertexIds.size != _.get(0).asInstanceOf[SparseVector].size)
-      val prInvalidSize = prInvalid.count()
+        .collect()
+        .filter { row: Row =>
+          vertexIds.size != row.get(0).asInstanceOf[SparseVector].size
+        }
+      val prInvalidSize = prInvalid.size
       if (0L != prInvalidSize) {
-        prInvalid.show(10)
+        //prInvalid.show(10)
         assert(false,
           s"found $prInvalidSize entries with invalid number of returned personalized pagerank vector")
       }

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -17,10 +17,10 @@
 
 package org.graphframes.lib
 
+import org.apache.spark.ml.linalg.{SparseVector, SQLDataTypes}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.Row
-import org.apache.spark.ml.linalg.{SparseVector, SQLDataTypes}
 
 import org.graphframes.examples.Graphs
 import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}
@@ -38,12 +38,12 @@ class ParallelPersonalizedPageRankSuite extends SparkFunSuite with GraphFrameTes
       g.parallelPersonalizedPageRank.sourceIds(vertexIds).run()
     }
 
-    // Not providing sources
+    // Not providing sourceIds
     intercept[IllegalArgumentException] {
       g.parallelPersonalizedPageRank.maxIter(15).run()
     }
 
-    // Provided empty sources
+    // Provided empty sourceIds
     intercept[IllegalArgumentException] {
       g.parallelPersonalizedPageRank.maxIter(15).sourceIds(Array()).run()
     }

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graphframes.lib
+
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.Row
+import org.apache.spark.ml.linalg.{SQLDataTypes, SparseVector}
+import org.apache.spark.util.VersionUtils
+
+import org.graphframes.examples.Graphs
+import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}
+
+class ParallelPersonalizedPageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
+
+  val n = 100
+
+  private def isLaterVersion(minVer: String): Boolean = {
+    val (minVersionMajor, minVersionMinor) = majorMinorVersion(minVer)
+    if (sparkVersionMajor != minVersionMajor) {
+      return sparkVersionMajor > minVersionMajor
+    } else {
+      return sparkVersionMinor >= minVersionMinor
+    }
+  }
+
+  test("Star example parallel personalized PageRank") {
+    val g = Graphs.star(n)
+    val resetProb = 0.15
+    val numIter = 10
+    val vertexIds: Array[Any] = Array(1L, 2L, 3L)
+
+    lazy val prc = g.parallelPersonalizedPageRank
+      .numIter(numIter)
+      .sources(vertexIds)
+      .resetProbability(resetProb)
+
+    if (isLaterVersion("2.1")) {
+      val pr = prc.run()
+      TestUtils.testSchemaInvariants(g, pr)
+      TestUtils.checkColumnType(pr.vertices.schema, "pagerank", SQLDataTypes.VectorType)
+      TestUtils.checkColumnType(pr.edges.schema, "weight", DataTypes.DoubleType)
+    } else {
+      intercept[NotImplementedError] { prc.run() }
+    }
+  }
+
+  test("friends graph with parallel personalized PageRank") {
+    val g = Graphs.friends
+    val resetProb = 0.15
+    val numIter = 10
+    val vertexIds: Array[Any] = Array("a")
+    lazy val prc = g.parallelPersonalizedPageRank
+      .numIter(numIter)
+      .sources(vertexIds)
+      .resetProbability(resetProb)
+
+    if (isLaterVersion("2.1")) {
+      val pr = prc.run()
+      val prInvalid = pr.vertices
+        .select("pagerank")
+        .collect()
+        .filter { row: Row =>
+          vertexIds.size != row.getAs[SparseVector](0).size
+        }
+      assert(prInvalid.size === 0,
+        s"found ${prInvalid.size} entries with invalid number of returned personalized pagerank vector")
+
+      val gRank = pr.vertices
+        .filter(col("id") === "g")
+        .select("pagerank")
+        .first().get(0).asInstanceOf[SparseVector]
+      assert(gRank.numNonzeros === 0,
+        s"User g (Gabby) doesn't connect with a. So its pagerank should be 0 but we got ${gRank.numNonzeros}.")
+    } else {
+      intercept[NotImplementedError] { prc.run() }
+    }
+  }
+
+}

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -38,6 +38,27 @@ class ParallelPersonalizedPageRankSuite extends SparkFunSuite with GraphFrameTes
     }
   }
 
+  test("Illegal function call argument setting") {
+    val g = Graphs.star(n)
+    val vertexIds: Array[Any] = Array(1L, 2L, 3L)
+
+    def checkPageRankRun(prc: ParallelPersonalizedPageRank): Unit = {
+      if (isLaterVersion("2.1")) {
+        intercept[IllegalArgumentException] { prc.run() }
+      } else {
+        intercept[NotImplementedError] { prc.run() }
+      }
+    }
+
+    lazy val prcSansNumIter = g.parallelPersonalizedPageRank
+      .sources(vertexIds)
+    checkPageRankRun(prcSansNumIter)
+
+    lazy val prcSansVertexIds = g.parallelPersonalizedPageRank
+      .numIter(15)
+    checkPageRankRun(prcSansVertexIds)
+  }
+
   test("Star example parallel personalized PageRank") {
     val g = Graphs.star(n)
     val resetProb = 0.15

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -21,7 +21,6 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
 import org.apache.spark.sql.Row
 import org.apache.spark.ml.linalg.{SQLDataTypes, SparseVector}
-import org.apache.spark.util.VersionUtils
 
 import org.graphframes.examples.Graphs
 import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}


### PR DESCRIPTION
This PR adds a wrapper for the `ParallelPersonalizedPageRank` implementation (available in Spark `2.1`). 
The API mirrors the corresponding `GraphX` implementation where the resulting `GraphFrame` instance `g` contains a `pagerank` column in the `g.vertices` and a `weight` column in `g.edges`. The `pagerank` column stores the PageRanks from all input source vertices as a sparse vector. 

@jkbradley @mengxr 