### PR TITLE
[WIP] [#159] Fix non-deterministic ID assignment

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -466,8 +466,8 @@ class GraphFrame private(
         col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
       val withLongIds = vertices.select(ID)
+        .repartition(col(ID))
         .distinct()
-        .repartition(1024, col(ID))
         .sortWithinPartitions(ID)
         .withColumn(LONG_ID, monotonically_increasing_id())
         .persist(StorageLevel.MEMORY_AND_DISK)


### PR DESCRIPTION
This is a WIP PR that tries to fix nondeterministic vertex ID assignment in GraphFrames (#159). We used to convert vertex DF to RDD and use zipWithUniqueID there. However, if the input DF is not deterministic, the outcome is still nondeterministic. This PR use hash partition + distinct + sort within partition for the ID assignment. Apparently this is more expensive, but hopefully this leads to correct result.

This is the generated plan. It seems correct (not pushing mono_id down).
~~~
scala> spark.range(1000).repartition('id).distinct().sortWithinPartitions('id).withColumn("long_id", monotonically_increasing_id()).explain()

== Physical Plan ==
*Project [id#7L, monotonically_increasing_id() AS long_id#13L]
+- *Sort [id#7L ASC NULLS FIRST], false, 0
   +- *HashAggregate(keys=[id#7L], functions=[])
      +- *HashAggregate(keys=[id#7L], functions=[])
         +- Exchange hashpartitioning(id#7L, 200)
            +- *Range (0, 1000, step=1, splits=Some(4))
~~~

The PR is still WIP. Once we confirm this is the right fix, I will clean up the code and add tests.

@nchammas Could you help test this patch? I don't have data to reproduce the issue. Thanks a lot!