### PR TITLE
[WIP][159] Fix non-deterministic ID assignment

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -466,8 +466,8 @@ class GraphFrame private(
         col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
       val withLongIds = vertices.select(ID)
+        .repartition(col(ID))
         .distinct()
-        .repartition(1024, col(ID))
         .sortWithinPartitions(ID)
         .withColumn(LONG_ID, monotonically_increasing_id())
         .persist(StorageLevel.MEMORY_AND_DISK)

--- a/src/main/spark-1.x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/sql/SQLHelpers.scala
@@ -26,21 +26,6 @@ object SQLHelpers {
 
   def expr(e: String): Column = functions.expr(e)
 
-  /**
-   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020 and SPARK-13473.
-   */
-  def zipWithUniqueId(df: DataFrame): DataFrame = {
-    val sqlContext = df.sqlContext
-    val schema = df.schema
-    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
-      Row(row, id)
-    }
-    val outputSchema = StructType(Seq(
-      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
-    sqlContext.createDataFrame(rdd, outputSchema)
-  }
-
   def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
     org.apache.spark.sql.functions.callUDF(f, returnType, arg1)
   }

--- a/src/main/spark-2.x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/sql/SQLHelpers.scala
@@ -26,21 +26,6 @@ object SQLHelpers {
 
   def expr(e: String): Column = functions.expr(e)
 
-  /**
-   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020 and SPARK-13473.
-   */
-  def zipWithUniqueId(df: DataFrame): DataFrame = {
-    val sqlContext = df.sqlContext
-    val schema = df.schema
-    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
-      Row(row, id)
-    }
-    val outputSchema = StructType(Seq(
-      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
-    sqlContext.createDataFrame(rdd, outputSchema)
-  }
-
   def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
     val u = udf(f, returnType)
     u(arg1)


### PR DESCRIPTION
This is a follow up task from [#189]. 
It removes `SQLHelpers.zipWithUniqueId` which is no longer needed.
We will make scalability test and address potential issues.
In the end, we will make a bug-fix release based on changes in this PR.
