### PR TITLE
[#159] Fix non-deterministic ID assignment

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -22,9 +22,8 @@ import java.util.Random
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.graphx.{Edge, Graph}
-import org.apache.spark.sql.SQLHelpers._
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions.{array, broadcast, col, count, explode, struct, udf}
+import org.apache.spark.sql.functions.{array, broadcast, col, count, explode, struct, udf, monotonically_increasing_id}
 import org.apache.spark.sql.types._
 import org.apache.spark.storage.StorageLevel
 
@@ -476,8 +475,15 @@ class GraphFrame private(
       indexedVertices.select(
         col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
-      val indexedVertices = zipWithUniqueId(vertices)
-      indexedVertices.select(col("uniq_id").as(LONG_ID), col("row." + ID).as(ID), col("row").as(ATTR))
+      val withLongIds = vertices.select(ID)
+        .distinct()
+        .repartition(1024, col(ID))
+        .sortWithinPartitions(ID)
+        .withColumn(LONG_ID, monotonically_increasing_id())
+        .persist(StorageLevel.MEMORY_AND_DISK)
+      vertices.select(col(ID), nestAsCol(vertices, ATTR))
+        .join(withLongIds, ID)
+        .select(LONG_ID, ID, ATTR)
     }
   }
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -476,8 +476,8 @@ class GraphFrame private(
         col(ATTR + "." + ID).cast("long").as(LONG_ID), col(ATTR + "." + ID).as(ID), col(ATTR))
     } else {
       val withLongIds = vertices.select(ID)
+        .repartition(col(ID))
         .distinct()
-        .repartition(1024, col(ID))
         .sortWithinPartitions(ID)
         .withColumn(LONG_ID, monotonically_increasing_id())
         .persist(StorageLevel.MEMORY_AND_DISK)

--- a/src/main/spark-1.x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-1.x/org/apache/spark/sql/SQLHelpers.scala
@@ -26,21 +26,6 @@ object SQLHelpers {
 
   def expr(e: String): Column = functions.expr(e)
 
-  /**
-   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020 and SPARK-13473.
-   */
-  def zipWithUniqueId(df: DataFrame): DataFrame = {
-    val sqlContext = df.sqlContext
-    val schema = df.schema
-    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
-      Row(row, id)
-    }
-    val outputSchema = StructType(Seq(
-      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
-    sqlContext.createDataFrame(rdd, outputSchema)
-  }
-
   def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
     org.apache.spark.sql.functions.callUDF(f, returnType, arg1)
   }

--- a/src/main/spark-2.0/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-2.0/org/apache/spark/sql/SQLHelpers.scala
@@ -26,21 +26,6 @@ object SQLHelpers {
 
   def expr(e: String): Column = functions.expr(e)
 
-  /**
-   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020 and SPARK-13473.
-   */
-  def zipWithUniqueId(df: DataFrame): DataFrame = {
-    val sqlContext = df.sqlContext
-    val schema = df.schema
-    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
-      Row(row, id)
-    }
-    val outputSchema = StructType(Seq(
-      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
-    sqlContext.createDataFrame(rdd, outputSchema)
-  }
-
   def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
     val u = udf(f, returnType)
     u(arg1)

--- a/src/main/spark-2.x/org/apache/spark/sql/SQLHelpers.scala
+++ b/src/main/spark-2.x/org/apache/spark/sql/SQLHelpers.scala
@@ -26,21 +26,6 @@ object SQLHelpers {
 
   def expr(e: String): Column = functions.expr(e)
 
-  /**
-   * Appends each record with a unique ID (uniq_id) and groups existing fields under column "row".
-   * This is a workaround for SPARK-9020 and SPARK-13473.
-   */
-  def zipWithUniqueId(df: DataFrame): DataFrame = {
-    val sqlContext = df.sqlContext
-    val schema = df.schema
-    val rdd = df.rdd.zipWithUniqueId().map { case (row, id) =>
-      Row(row, id)
-    }
-    val outputSchema = StructType(Seq(
-      StructField("row", schema, false), StructField("uniq_id", LongType, false)))
-    sqlContext.createDataFrame(rdd, outputSchema)
-  }
-
   def callUDF(f: Function1[_, _], returnType: DataType, arg1: Column): Column = {
     val u = udf(f, returnType)
     u(arg1)

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -159,46 +159,48 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
   }
 
   test("checkpoint interval") {
-    val friends = Graphs.friends
-    val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
+    if (isLaterVersion("2.0")) {
+      val friends = Graphs.friends
+      val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
 
-    val cc = new ConnectedComponents(friends)
-    assert(cc.getCheckpointInterval === 2,
-      s"Default checkpoint interval should be 2, but got ${cc.getCheckpointInterval}.")
+      val cc = new ConnectedComponents(friends)
+      assert(cc.getCheckpointInterval === 2,
+        s"Default checkpoint interval should be 2, but got ${cc.getCheckpointInterval}.")
 
-    val checkpointDir = sc.getCheckpointDir
-    assert(checkpointDir.nonEmpty)
+      val checkpointDir = sc.getCheckpointDir
+      assert(checkpointDir.nonEmpty)
 
-    sc.setCheckpointDir(null)
-    withClue("Should throw an IOException if sc.getCheckpointDir is empty " +
-      "and checkpointInterval is positive.") {
-      intercept[IOException] {
-        cc.run()
+      sc.setCheckpointDir(null)
+      withClue("Should throw an IOException if sc.getCheckpointDir is empty " +
+        "and checkpointInterval is positive.") {
+        intercept[IOException] {
+          cc.run()
+        }
       }
+
+      // Checks whether the input DataFrame is from some checkpoint data.
+      // TODO: The implemetnation is a little hacky.
+      def isFromCheckpoint(df: DataFrame): Boolean = {
+        df.queryExecution.logical.toString().toLowerCase.contains("parquet")
+      }
+
+      val components0 = cc.setCheckpointInterval(0).run()
+      assertComponents(components0, expected)
+      assert(!isFromCheckpoint(components0),
+        "The result shouldn't depend on checkpoint data if checkpointing is disabled.")
+
+      sc.setCheckpointDir(checkpointDir.get)
+
+      val components1 = cc.setCheckpointInterval(1).run()
+      assertComponents(components1, expected)
+      assert(isFromCheckpoint(components1),
+        "The result should depend on checkpoint data if checkpoint interval is 1.")
+
+      val components10 = cc.setCheckpointInterval(10).run()
+      assertComponents(components10, expected)
+      assert(!isFromCheckpoint(components10),
+        "The result shouldn't depend on checkpoint data if converged before first checkpoint.")
     }
-
-    // Checks whether the input DataFrame is from some checkpoint data.
-    // TODO: The implemetnation is a little hacky.
-    def isFromCheckpoint(df: DataFrame): Boolean = {
-      df.queryExecution.logical.toString().toLowerCase.contains("parquet")
-    }
-
-    val components0 = cc.setCheckpointInterval(0).run()
-    assertComponents(components0, expected)
-    assert(!isFromCheckpoint(components0),
-      "The result shouldn't depend on checkpoint data if checkpointing is disabled.")
-
-    sc.setCheckpointDir(checkpointDir.get)
-
-    val components1 = cc.setCheckpointInterval(1).run()
-    assertComponents(components1, expected)
-    assert(isFromCheckpoint(components1),
-      "The result should depend on checkpoint data if checkpoint interval is 1.")
-
-    val components10 = cc.setCheckpointInterval(10).run()
-    assertComponents(components10, expected)
-    assert(!isFromCheckpoint(components10),
-      "The result shouldn't depend on checkpoint data if converged before first checkpoint.")
   }
 
   private def assertComponents[T: ClassTag:TypeTag](

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -183,6 +183,8 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
       df.queryExecution.logical.toString().toLowerCase.contains("parquet")
     }
 
+    // [#194] Prior to Apache Spark version 2.0, not having checkpoint
+    //        causes the test to run for too long, resulting in Travis CI to abort the build
     if (isLaterVersion("2.0")) {
       val components0 = cc.setCheckpointInterval(0).run()
       assertComponents(components0, expected)
@@ -197,6 +199,8 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     assert(isFromCheckpoint(components1),
       "The result should depend on checkpoint data if checkpoint interval is 1.")
 
+    // [#194] Prior to Apache Spark version 2.0, having long checkpoint interval
+    //        causes the test to run for too long, resulting in Travis CI to abort the build
     if (isLaterVersion("2.0")) {
       val components10 = cc.setCheckpointInterval(10).run()
       assertComponents(components10, expected)

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -159,43 +159,45 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
   }
 
   test("checkpoint interval") {
+    val friends = Graphs.friends
+    val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
+
+    val cc = new ConnectedComponents(friends)
+    assert(cc.getCheckpointInterval === 2,
+      s"Default checkpoint interval should be 2, but got ${cc.getCheckpointInterval}.")
+
+    val checkpointDir = sc.getCheckpointDir
+    assert(checkpointDir.nonEmpty)
+
+    sc.setCheckpointDir(null)
+    withClue("Should throw an IOException if sc.getCheckpointDir is empty " +
+      "and checkpointInterval is positive.") {
+      intercept[IOException] {
+        cc.run()
+      }
+    }
+
+    // Checks whether the input DataFrame is from some checkpoint data.
+    // TODO: The implemetnation is a little hacky.
+    def isFromCheckpoint(df: DataFrame): Boolean = {
+      df.queryExecution.logical.toString().toLowerCase.contains("parquet")
+    }
+
     if (isLaterVersion("2.0")) {
-      val friends = Graphs.friends
-      val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
-
-      val cc = new ConnectedComponents(friends)
-      assert(cc.getCheckpointInterval === 2,
-        s"Default checkpoint interval should be 2, but got ${cc.getCheckpointInterval}.")
-
-      val checkpointDir = sc.getCheckpointDir
-      assert(checkpointDir.nonEmpty)
-
-      sc.setCheckpointDir(null)
-      withClue("Should throw an IOException if sc.getCheckpointDir is empty " +
-        "and checkpointInterval is positive.") {
-        intercept[IOException] {
-          cc.run()
-        }
-      }
-
-      // Checks whether the input DataFrame is from some checkpoint data.
-      // TODO: The implemetnation is a little hacky.
-      def isFromCheckpoint(df: DataFrame): Boolean = {
-        df.queryExecution.logical.toString().toLowerCase.contains("parquet")
-      }
-
       val components0 = cc.setCheckpointInterval(0).run()
       assertComponents(components0, expected)
       assert(!isFromCheckpoint(components0),
         "The result shouldn't depend on checkpoint data if checkpointing is disabled.")
+    }
 
-      sc.setCheckpointDir(checkpointDir.get)
+    sc.setCheckpointDir(checkpointDir.get)
 
-      val components1 = cc.setCheckpointInterval(1).run()
-      assertComponents(components1, expected)
-      assert(isFromCheckpoint(components1),
-        "The result should depend on checkpoint data if checkpoint interval is 1.")
+    val components1 = cc.setCheckpointInterval(1).run()
+    assertComponents(components1, expected)
+    assert(isFromCheckpoint(components1),
+      "The result should depend on checkpoint data if checkpoint interval is 1.")
 
+    if (isLaterVersion("2.0")) {
       val components10 = cc.setCheckpointInterval(10).run()
       assertComponents(components10, expected)
       assert(!isFromCheckpoint(components10),


### PR DESCRIPTION
This is a follow up task from [#189].
It removes SQLHelpers.zipWithUniqueId which is no longer needed.
We will make scalability test and address potential issues.
In the end, we will make a bug-fix release based on changes in this PR.
