### PR TITLE
[57] [170] aggregateMessages for python update

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -885,8 +885,8 @@ msgToSrc = AM.dst["age"]
 msgToDst = AM.src["age"]
 agg = g.aggregateMessages(
     sqlsum(AM.msg).alias("summedAges"),
-    msgToSrc=msgToSrc,
-    msgToDst=msgToDst)
+    sendToSrc=msgToSrc,
+    sendToDst=msgToDst)
 agg.show()
 
 {% endhighlight %}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -876,7 +876,7 @@ For API details, refer to the
 
 {% highlight python %}
 from pyspark.sql.functions import sum as sqlsum
-from graphframes import AggregateMessages as AM
+from graphframes.lib import AggregateMessages as AM
 from graphframes.examples import Graphs
 g = Graphs(sqlContext).friends()  # Get example graph
 

--- a/python/docs/graphframes.lib.rst
+++ b/python/docs/graphframes.lib.rst
@@ -1,0 +1,10 @@
+graphframes.lib package
+=======================
+
+Collection of utilities usable with message aggregation
+-------------------------------------------------------
+
+.. automodule:: graphframes.lib
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/python/docs/graphframes.rst
+++ b/python/docs/graphframes.rst
@@ -9,6 +9,8 @@ Subpackages
 
     graphframes.examples
 
+    graphframes.lib
+
 Contents
 --------
 

--- a/python/graphframes/__init__.py
+++ b/python/graphframes/__init__.py
@@ -1,4 +1,4 @@
 
-from .graphframe import GraphFrame, AggregateMessages
+from .graphframe import GraphFrame
 
-__all__ = ['GraphFrame', 'AggregateMessages']
+__all__ = ['GraphFrame']

--- a/python/graphframes/examples/belief_propagation.py
+++ b/python/graphframes/examples/belief_propagation.py
@@ -21,7 +21,8 @@ from pyspark import SparkConf, SparkContext
 from pyspark.sql import SQLContext, functions as sqlfunctions, types
 from pyspark.tests import QuietTest as SuppressSparkLogs
 
-from graphframes import GraphFrame, AggregateMessages as AM
+from graphframes import GraphFrame
+from graphframes.lib import AggregateMessages as AM
 # Import subpackage examples here explicitly so that this module can be
 # run directly with spark-submit.
 import graphframes.examples

--- a/python/graphframes/examples/belief_propagation.py
+++ b/python/graphframes/examples/belief_propagation.py
@@ -95,8 +95,8 @@ class BeliefPropagation(object):
                 logistic = sqlfunctions.udf(cls._sigmoid, returnType=types.DoubleType())
                 aggregates = gx.aggregateMessages(
                     sqlfunctions.sum(AM.msg).alias("aggMess"),
-                    msgToSrc=msgForSrc,
-                    msgToDst=msgForDst)
+                    sendToSrc=msgForSrc,
+                    sendToDst=msgForDst)
                 v = gx.vertices
                 # receive messages and update beliefs for vertices of the current color
                 newBeliefCol = sqlfunctions.when(

--- a/python/graphframes/examples/graphs.py
+++ b/python/graphframes/examples/graphs.py
@@ -85,8 +85,11 @@ class Graphs(object):
             run on this model. Vertex IDs are of the form "i,j".  E.g., vertex "1,3" is in the
             second row and fourth column of the grid.
         """
-        assert n >= 1,\
-            "Grid graph must have size >= 1, but was given invalid value n = {}".format(n)
+        # check param n
+        if n < 1:
+            raise ValueError(
+                "Grid graph must have size >= 1, but was given invalid value n = {}"
+                .format(n))
 
         # create coodinates grid
         coordinates = self._sql.createDataFrame(

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -415,7 +415,7 @@ class AggregateMessages(object):
         """
         Create a new cached copy of a DataFrame.
 
-        This utility method is usefull for iterative DataFrame-based algorithms. See Scala
+        This utility method is useful for iterative DataFrame-based algorithms. See Scala
         documentation for more details.
 
         WARNING: This is NOT the same as `DataFrame.cache()`.

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -214,7 +214,7 @@ class GraphFrame(object):
         Aggregates messages from the neighbours.
 
         When specifying the messages and aggregation function, the user may reference columns using
-        the static methods in :class:`AggregateMessages`.
+        the static methods in :class:`graphframes.lib.AggregateMessages`.
 
         See Scala documentation for more details.
 

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -20,7 +20,7 @@ if sys.version > '3':
     basestring = str
 
 from pyspark import SparkContext
-from pyspark.sql import Column, DataFrame, functions as sqlfunctions, SQLContext
+from pyspark.sql import Column, DataFrame, SQLContext
 from pyspark.storagelevel import StorageLevel
 
 def _from_java_gf(jgf, sqlContext):
@@ -367,64 +367,6 @@ class GraphFrame(object):
         """
         jdf = self._jvm_graph.triangleCount().run()
         return DataFrame(jdf, self._sqlContext)
-
-
-class _ClassProperty(object):
-    """Custom read-only class property descriptor.
-
-    The underlying method should take the class as the sole argument.
-    """
-
-    def __init__(self, f):
-        self.f = f
-        self.__doc__ = f.__doc__
-
-    def __get__(self, instance, owner):
-        return self.f(owner)
-
-
-class AggregateMessages(object):
-    """Collection of utilities usable with :meth:`GraphFrame.aggregateMessages()`."""
-
-    @_ClassProperty
-    def src(cls):
-        """Reference for source column, used for specifying messages."""
-        jvm_gf_api = _java_api(SparkContext)
-        return sqlfunctions.col(jvm_gf_api.SRC())
-
-    @_ClassProperty
-    def dst(cls):
-        """Reference for destination column, used for specifying messages."""
-        jvm_gf_api = _java_api(SparkContext)
-        return sqlfunctions.col(jvm_gf_api.DST())
-
-    @_ClassProperty
-    def edge(cls):
-        """Reference for edge column, used for specifying messages."""
-        jvm_gf_api = _java_api(SparkContext)
-        return sqlfunctions.col(jvm_gf_api.EDGE())
-
-    @_ClassProperty
-    def msg(cls):
-        """Reference for message column, used for specifying aggregation function."""
-        jvm_gf_api = _java_api(SparkContext)
-        return sqlfunctions.col(jvm_gf_api.aggregateMessages().MSG_COL_NAME())
-
-    @staticmethod
-    def getCachedDataFrame(df):
-        """
-        Create a new cached copy of a DataFrame.
-
-        This utility method is useful for iterative DataFrame-based algorithms. See Scala
-        documentation for more details.
-
-        WARNING: This is NOT the same as `DataFrame.cache()`.
-                 The original DataFrame will NOT be cached.
-        """
-        sqlContext = df.sql_ctx
-        jvm_gf_api = _java_api(sqlContext._sc)
-        jdf = jvm_gf_api.aggregateMessages().getCachedDataFrame(df._jdf)
-        return DataFrame(jdf, sqlContext)
 
 
 def _test():

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -15,6 +15,10 @@
 # limitations under the License.
 #
 
+import sys
+if sys.version > '3':
+    basestring = str
+
 from pyspark import SparkContext
 from pyspark.sql import Column, DataFrame, functions as sqlfunctions, SQLContext
 from pyspark.storagelevel import StorageLevel
@@ -215,11 +219,11 @@ class GraphFrame(object):
         See Scala documentation for more details.
 
         :param aggCol: the requested aggregation output either as
-            `pyspark.sql.Column` or SQL expression string
+            :class:`pyspark.sql.Column` or SQL expression string
         :param msgToSrc: message sent to the source vertex of each triplet either as
-            `pyspark.sql.Column` or SQL expression string (default: None)
+            :class:`pyspark.sql.Column` or SQL expression string (default: None)
         :param msgToDst: message sent to the destination vertex of each triplet either as
-            `pyspark.sql.Column` or SQL expression string (default: None)
+            :class:`pyspark.sql.Column` or SQL expression string (default: None)
 
         :return: DataFrame with columns for the vertex ID and the resulting aggregated message
         """
@@ -230,13 +234,17 @@ class GraphFrame(object):
         if msgToSrc is not None:
             if isinstance(msgToSrc, Column):
                 builder.sendToSrc(msgToSrc._jc)
-            else:
+            elif isinstance(msgToSrc, basestring):
                 builder.sendToSrc(msgToSrc)
+            else:
+                raise TypeError("Provide message either as `Column` or `str`")
         if msgToDst is not None:
             if isinstance(msgToDst, Column):
                 builder.sendToDst(msgToDst._jc)
-            else:
+            elif isinstance(msgToDst, basestring):
                 builder.sendToDst(msgToDst)
+            else:
+                raise TypeError("Provide message either as `Column` or `str`")
         if isinstance(aggCol, Column):
             jdf = builder.agg(aggCol._jc)
         else:

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -64,7 +64,6 @@ class GraphFrame(object):
         self._sc = self._sqlContext._sc
         self._sc._jvm.org.apache.spark.ml.feature.Tokenizer()
         self._jvm_gf_api = _java_api(self._sc)
-        self._jvm_graph = self._jvm_gf_api.createGraph(v._jdf, e._jdf)
 
         self.ID = self._jvm_gf_api.ID()
         self.SRC = self._jvm_gf_api.SRC()
@@ -84,6 +83,8 @@ class GraphFrame(object):
             raise ValueError(
                 "Destination vertex ID column {} missing from edge DataFrame, which has columns: {}"
                 .format(self.DST, ",".join(e.columns)))
+
+        self._jvm_graph = self._jvm_gf_api.createGraph(v._jdf, e._jdf)
 
     @property
     def vertices(self):

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -209,7 +209,7 @@ class GraphFrame(object):
         jdf = builder.run()
         return DataFrame(jdf, self._sqlContext)
 
-    def aggregateMessages(self, aggCol, msgToSrc=None, msgToDst=None):
+    def aggregateMessages(self, aggCol, sendToSrc=None, sendToDst=None):
         """
         Aggregates messages from the neighbours.
 
@@ -220,29 +220,29 @@ class GraphFrame(object):
 
         :param aggCol: the requested aggregation output either as
             :class:`pyspark.sql.Column` or SQL expression string
-        :param msgToSrc: message sent to the source vertex of each triplet either as
+        :param sendToSrc: message sent to the source vertex of each triplet either as
             :class:`pyspark.sql.Column` or SQL expression string (default: None)
-        :param msgToDst: message sent to the destination vertex of each triplet either as
+        :param sendToDst: message sent to the destination vertex of each triplet either as
             :class:`pyspark.sql.Column` or SQL expression string (default: None)
 
         :return: DataFrame with columns for the vertex ID and the resulting aggregated message
         """
-        # Check that either msgToSrc, msgToDst, or both are provided
-        if msgToSrc is None and msgToDst is None:
-            raise ValueError("Either `msgToSrc`, `msgToDst`, or both have to be provided")
+        # Check that either sendToSrc, sendToDst, or both are provided
+        if sendToSrc is None and sendToDst is None:
+            raise ValueError("Either `sendToSrc`, `sendToDst`, or both have to be provided")
         builder = self._jvm_graph.aggregateMessages()
-        if msgToSrc is not None:
-            if isinstance(msgToSrc, Column):
-                builder.sendToSrc(msgToSrc._jc)
-            elif isinstance(msgToSrc, basestring):
-                builder.sendToSrc(msgToSrc)
+        if sendToSrc is not None:
+            if isinstance(sendToSrc, Column):
+                builder.sendToSrc(sendToSrc._jc)
+            elif isinstance(sendToSrc, basestring):
+                builder.sendToSrc(sendToSrc)
             else:
                 raise TypeError("Provide message either as `Column` or `str`")
-        if msgToDst is not None:
-            if isinstance(msgToDst, Column):
-                builder.sendToDst(msgToDst._jc)
-            elif isinstance(msgToDst, basestring):
-                builder.sendToDst(msgToDst)
+        if sendToDst is not None:
+            if isinstance(sendToDst, Column):
+                builder.sendToDst(sendToDst._jc)
+            elif isinstance(sendToDst, basestring):
+                builder.sendToDst(sendToDst)
             else:
                 raise TypeError("Provide message either as `Column` or `str`")
         if isinstance(aggCol, Column):

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -71,15 +71,19 @@ class GraphFrame(object):
         self.DST = self._jvm_gf_api.DST()
         self._ATTR = self._jvm_gf_api.ATTR()
 
-        assert self.ID in v.columns,\
-            "Vertex ID column '%s' missing from vertex DataFrame, which has columns: %s" %\
-            (self.ID, ",".join(v.columns))
-        assert self.SRC in e.columns,\
-            "Source vertex ID column '%s' missing from edge DataFrame, which has columns: %s" %\
-            (self.SRC, ",".join(e.columns))
-        assert self.DST in e.columns,\
-            "Destination vertex ID column '%s' missing from edge DataFrame, which has columns: %s"%\
-            (self.DST, ",".join(e.columns))
+        # Check that provided DataFrames contain required columns
+        if self.ID not in v.columns:
+            raise ValueError(
+                "Vertex ID column {} missing from vertex DataFrame, which has columns: {}"
+                .format(self.ID, ",".join(v.columns)))
+        if self.SRC not in e.columns:
+            raise ValueError(
+                "Source vertex ID column {} missing from edge DataFrame, which has columns: {}"
+                .format(self.SRC, ",".join(e.columns)))
+        if self.DST not in e.columns:
+            raise ValueError(
+                "Destination vertex ID column {} missing from edge DataFrame, which has columns: {}"
+                .format(self.DST, ",".join(e.columns)))
 
     @property
     def vertices(self):

--- a/python/graphframes/lib/__init__.py
+++ b/python/graphframes/lib/__init__.py
@@ -1,0 +1,4 @@
+
+from .aggregate_messages import AggregateMessages
+
+__all__ = ['AggregateMessages']

--- a/python/graphframes/lib/aggregate_messages.py
+++ b/python/graphframes/lib/aggregate_messages.py
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark import SparkContext
+from pyspark.sql import DataFrame, functions as sqlfunctions
+
+
+def _java_api(jsc):
+    javaClassName = "org.graphframes.GraphFramePythonAPI"
+    return jsc._jvm.Thread.currentThread().getContextClassLoader().loadClass(javaClassName) \
+            .newInstance()
+
+
+class _ClassProperty(object):
+    """Custom read-only class property descriptor.
+
+    The underlying method should take the class as the sole argument.
+    """
+
+    def __init__(self, f):
+        self.f = f
+        self.__doc__ = f.__doc__
+
+    def __get__(self, instance, owner):
+        return self.f(owner)
+
+
+class AggregateMessages(object):
+    """Collection of utilities usable with :meth:`graphframes.GraphFrame.aggregateMessages()`."""
+
+    @_ClassProperty
+    def src(cls):
+        """Reference for source column, used for specifying messages."""
+        jvm_gf_api = _java_api(SparkContext)
+        return sqlfunctions.col(jvm_gf_api.SRC())
+
+    @_ClassProperty
+    def dst(cls):
+        """Reference for destination column, used for specifying messages."""
+        jvm_gf_api = _java_api(SparkContext)
+        return sqlfunctions.col(jvm_gf_api.DST())
+
+    @_ClassProperty
+    def edge(cls):
+        """Reference for edge column, used for specifying messages."""
+        jvm_gf_api = _java_api(SparkContext)
+        return sqlfunctions.col(jvm_gf_api.EDGE())
+
+    @_ClassProperty
+    def msg(cls):
+        """Reference for message column, used for specifying aggregation function."""
+        jvm_gf_api = _java_api(SparkContext)
+        return sqlfunctions.col(jvm_gf_api.aggregateMessages().MSG_COL_NAME())
+
+    @staticmethod
+    def getCachedDataFrame(df):
+        """
+        Create a new cached copy of a DataFrame.
+
+        This utility method is useful for iterative DataFrame-based algorithms. See Scala
+        documentation for more details.
+
+        WARNING: This is NOT the same as `DataFrame.cache()`.
+                 The original DataFrame will NOT be cached.
+        """
+        sqlContext = df.sql_ctx
+        jvm_gf_api = _java_api(sqlContext._sc)
+        jdf = jvm_gf_api.aggregateMessages().getCachedDataFrame(df._jdf)
+        return DataFrame(jdf, sqlContext)

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -31,8 +31,10 @@ else:
 from pyspark import SparkContext
 from pyspark.sql import DataFrame, functions as sqlfunctions, SQLContext
 
-from .graphframe import AggregateMessages as AM, GraphFrame, _java_api, _from_java_gf
+from .graphframe import GraphFrame, _java_api, _from_java_gf
+from .lib import AggregateMessages as AM
 from .examples import Graphs, BeliefPropagation
+
 
 class GraphFrameTestCase(unittest.TestCase):
 
@@ -101,6 +103,7 @@ class GraphFrameTest(GraphFrameTestCase):
         self.assertEqual(paths2.count(), 0)
         paths3 = g.bfs("name='A'", "name='C'", maxPathLength=1)
         self.assertEqual(paths3.count(), 0)
+
 
 class GraphFrameLibTest(GraphFrameTestCase):
     def setUp(self):
@@ -248,6 +251,7 @@ class GraphFrameLibTest(GraphFrameTestCase):
         c = g.triangleCount()
         for row in c.select("id", "count").collect():
             self.assertEqual(row.asDict()['count'], 1)
+
 
 class GraphFrameExamplesTest(GraphFrameTestCase):
     def setUp(self):

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -58,8 +58,8 @@ class GraphFrameTestCase(unittest.TestCase):
 class GraphFrameTest(GraphFrameTestCase):
     def setUp(self):
         super(GraphFrameTest, self).setUp()
-        localVertices = [(1,"A"), (2,"B"), (3, "C")]
-        localEdges = [(1,2,"love"), (2,1,"hate"), (2,3,"follow")]
+        localVertices = [(1, "A"), (2, "B"), (3, "C")]
+        localEdges = [(1, 2, "love"), (2, 1, "hate"), (2, 3, "follow")]
         v = self.sql.createDataFrame(localVertices, ["id", "name"])
         e = self.sql.createDataFrame(localEdges, ["src", "dst", "action"])
         self.g = GraphFrame(v, e)
@@ -73,6 +73,13 @@ class GraphFrameTest(GraphFrameTestCase):
         tripletsFirst = list(map(lambda x: (x[0][1], x[1][1], x[2][2]),
                             g.triplets.sort("src.id").select("src", "dst", "edge").take(1)))
         assert tripletsFirst == [("A", "B", "love")], tripletsFirst
+        # Try with invalid vertices and edges DataFrames
+        v_invalid = self.sql.createDataFrame(
+            [(1, "A"), (2, "B"), (3, "C")], ["invalid_colname_1", "invalid_colname_2"])
+        e_invalid = self.sql.createDataFrame(
+            [(1, 2), (2, 3), (3, 1)], ["invalid_colname_3", "invalid_colname_4"])
+        with self.assertRaises(ValueError):
+            GraphFrame(v_invalid, e_invalid)
 
     def test_cache(self):
         g = self.g


### PR DESCRIPTION
This PR implements the updates discussed in PR #169 post merge.

Updates:
- Move AggregateMessages under graphframes.lib
- rename `msgToX` into `sendToX`
- change parameter ``assert`` checks into raise errors
- check for string type (Python 2 and 3) for params `sendToX`