### PR TITLE
[184][Docs] Parallel Personalized PageRank docs update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,11 @@ in some cases:
     $ sudo gem install jekyll
     $ sudo gem install jekyll-redirect-from
 
+On macOS, with the default Ruby, please install Jekyll with Bundler as [instructed on offical website](https://jekyllrb.com/docs/quickstart/). Otherwise the build script might fail to resolve dependencies.
+
+    $ sudo gem install jekyll bundler
+    $ sudo gem install jekyll-redirect-from
+
 Execute `jekyll build` from the `docs/` directory to compile the site. Compiling the site with Jekyll will create a directory
 called `_site` containing index.html as well as the rest of the compiled files.
 
@@ -40,6 +45,8 @@ You can modify the default Jekyll build as follows:
     $ PRODUCTION=1 jekyll build
 
 Note that `SPARK_HOME` must be set to your local Spark installation in order to generate the docs.
+To manually point to a specific `Spark` installation,
+    $ SPARK_HOME=<your-path-to-spark-home> PRODUCTION=1 jekyll build
 
 ## Pygments
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -677,6 +677,9 @@ val results2 = g.pageRank.resetProbability(0.15).maxIter(10).run()
 
 // Run PageRank personalized for vertex "a"
 val results3 = g.pageRank.resetProbability(0.15).maxIter(10).sourceId("a").run()
+
+# Run PageRank personalized for vertex ["a", "b", "c", "d"] in parallel
+val results3 = g.pageRank.resetProbability(0.15).maxIter(10).sourceIds(Array("a", "b", "c", "d")).run()
 {% endhighlight %}
 </div>
 
@@ -701,7 +704,11 @@ results2 = g.pageRank(resetProbability=0.15, maxIter=10)
 
 # Run PageRank personalized for vertex "a"
 results3 = g.pageRank(resetProbability=0.15, maxIter=10, sourceId="a")
+
+# Run PageRank personalized for vertex ["a", "b", "c", "d"] in parallel
+results4 = g.parallelPersonalizedPageRank(resetProbability=0.15, sourceIds=["a", "b", "c", "d"], maxIter=10)
 {% endhighlight %}
+
 </div>
 
 </div>


### PR DESCRIPTION
This is a follow up `PR` to update the documentation of the `ParallelPersonalizedPageRank` [#184].
Docs are built following `docs/README.md`. 