### PR TITLE
Update release number for 0.5 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ env:
   matrix:
     - PYSPARK_PYTHON=python2 SCALA_VERSION=2.10.6 SPARK_VERSION=1.6.3 SPARK_BUILD="spark-1.6.3-bin-hadoop2.6" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-1.6.3-bin-hadoop2.6.tgz"
     - PYSPARK_PYTHON=python2 SCALA_VERSION=2.11.8 SPARK_VERSION=2.0.2 SPARK_BUILD="spark-2.0.2-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.0.2-bin-hadoop2.7.tgz"
-    - PYSPARK_PYTHON=python2 SCALA_VERSION=2.11.8 SPARK_VERSION=2.1.0 SPARK_BUILD="spark-2.1.0-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz"
+    - PYSPARK_PYTHON=python2 SCALA_VERSION=2.11.8 SPARK_VERSION=2.1.1 SPARK_BUILD="spark-2.1.1-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz"
     - PYSPARK_PYTHON=python3 SCALA_VERSION=2.10.6 SPARK_VERSION=1.6.3 SPARK_BUILD="spark-1.6.3-bin-hadoop2.6" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-1.6.3-bin-hadoop2.6.tgz"
     - PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.8 SPARK_VERSION=2.0.2 SPARK_BUILD="spark-2.0.2-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.0.2-bin-hadoop2.7.tgz"
-    - PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.8 SPARK_VERSION=2.1.0 SPARK_BUILD="spark-2.1.0-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.1.0-bin-hadoop2.7.tgz"
+    - PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.8 SPARK_VERSION=2.1.1 SPARK_BUILD="spark-2.1.1-bin-hadoop2.7" SPARK_BUILD_URL="http://d3kbcqa49mib13.cloudfront.net/spark-2.1.1-bin-hadoop2.7.tgz"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-all: 2.1.0s2.10 1.6.3 2.0.2 2.1.0
+all: 2.1.1s2.10 1.6.3 2.0.2 2.1.1
 
 clean:
 	rm -rf target/graphframes_*.zip
 
-1.6.3 2.0.2 2.1.0:
+1.6.3 2.0.2 2.1.1:
 	build/sbt -Dspark.version=$@ spDist
 
-2.1.0s2.10:
-	build/sbt -Dspark.version=2.1.0 -Dscala.version=2.10.6 spDist assembly test
+2.1.1s2.10:
+	build/sbt -Dspark.version=2.1.1 -Dscala.version=2.10.6 spDist assembly test

--- a/README.md
+++ b/README.md
@@ -32,10 +32,16 @@ We welcome open source contributions as well!
 ## Releases:
 
 - 0.1.0 initial release
-- 0.2.0 release for Spark 2.0 (work of @felixcheung)
-- 0.3.0
+- 0.2.0 release
+  - Spark 2.0 support (work of @felixcheung)
+- 0.3.0 release
   - DataFrame-based connected components implementation
   - added support for Python 3
   - removed support for Spark 1.4 and 1.5
-- 0.4.0 release for Spark 2.1
+- 0.4.0 release
+  - Spark 2.1 support
   - Fix for checkpointing issue in DataFrame-based connected components implementation (issue 160)
+- 0.5.0 release
+  - Major bug fix: Indexing non-Integer vertex IDs, which is used by algorithms which call GraphX
+    under the hood, including PageRank, ConnectedComponents, and others.
+  - aggregateMessages for Python API

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ scalaVersion := scalaVer
 spName := "graphframes/graphframes"
 
 // Don't forget to set the version
-version := s"0.4.0-SNAPSHOT-spark$sparkBranch"
+version := s"0.5.0-spark$sparkBranch"
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 // Your sbt build file. Guides on how to write one can be found at
 // http://www.scala-sbt.org/0.13/docs/index.html
 
-val sparkVer = sys.props.getOrElse("spark.version", "2.1.0")
+val sparkVer = sys.props.getOrElse("spark.version", "2.1.1")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
   case "1.6" => "2.10.6"

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,7 +14,7 @@ include:
 
 # These allow the documentation to be updated with newer releases
 # of Spark, Scala, and Mesos.
-GRAPHFRAMES_VERSION: 0.4.0
+GRAPHFRAMES_VERSION: 0.5.0
 #SCALA_BINARY_VERSION: "2.10"
 #SCALA_VERSION: "2.10.4"
 #MESOS_VERSION: 0.21.0

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,7 +30,7 @@ We use the `--packages` argument to download the graphframes package and any dep
 <div data-lang="scala"  markdown="1">
 
 {% highlight bash %}
-$ ./bin/spark-shell --packages graphframes:graphframes:0.4.0-spark2.0-s_2.11
+$ ./bin/spark-shell --packages graphframes:graphframes:0.5.0-spark2.1-s_2.11
 {% endhighlight %}
 
 </div>
@@ -38,7 +38,7 @@ $ ./bin/spark-shell --packages graphframes:graphframes:0.4.0-spark2.0-s_2.11
 <div data-lang="python"  markdown="1">
 
 {% highlight bash %}
-$ ./bin/pyspark --packages graphframes:graphframes:0.4.0-spark2.0-s_2.11
+$ ./bin/pyspark --packages graphframes:graphframes:0.5.0-spark2.1-s_2.11
 {% endhighlight %}
 
 </div>


### PR DESCRIPTION
Also cherry-picked https://github.com/graphframes/graphframes/pull/198 to update Travis to use spark 2.1.1 instead of 2.1.0