### PR TITLE
ConnectedComponents: test differing edge directions

### DIFF
--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -122,6 +122,18 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     assertComponents(components, expected)
   }
 
+  test("one component, differing edge directions") {
+    val vertices = sqlContext.range(5L).toDF(ID)
+    val edges = sqlContext.createDataFrame(Seq(
+      // 0 -> 4 -> 3 <- 2 -> 1
+      0L -> 4L, 4L -> 3L, 2L -> 3L, 2L -> 1L
+    )).toDF(SRC, DST)
+    val g = GraphFrame(vertices, edges)
+    val components = g.connectedComponents.run()
+    val expected = Set((0L to 4L).toSet)
+    assertComponents(components, expected)
+  }
+
   test("two components and two dangling vertices") {
     val vertices = sqlContext.range(8L).toDF(ID)
     val edges = sqlContext.createDataFrame(Seq(


### PR DESCRIPTION
I ran into this porting some graphx code to graphframes in some of my own unit tests. I dunno what's going on yet, but it appears to be minimal, after trying to shrink the test case manually.