### PR TITLE
[208] Fix cc min nbr in small star

### DIFF
--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -122,6 +122,18 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     assertComponents(components, expected)
   }
 
+  test("one component, differing edge directions") {
+    val vertices = sqlContext.range(5L).toDF(ID)
+    val edges = sqlContext.createDataFrame(Seq(
+      // 0 -> 4 -> 3 <- 2 -> 1
+      0L -> 4L, 4L -> 3L, 2L -> 3L, 2L -> 1L
+    )).toDF(SRC, DST)
+    val g = GraphFrame(vertices, edges)
+    val components = g.connectedComponents.run()
+    val expected = Set((0L to 4L).toSet)
+    assertComponents(components, expected)
+  }
+
   test("two components and two dangling vertices") {
     val vertices = sqlContext.range(8L).toDF(ID)
     val edges = sqlContext.createDataFrame(Seq(

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -126,7 +126,7 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     val vertices = sqlContext.range(5L).toDF(ID)
     val edges = sqlContext.createDataFrame(Seq(
       // 0 -> 4 -> 3 <- 2 -> 1
-      0L -> 4L, 4L -> 3L, 2L -> 3L, 2L -> 1L
+      (0L, 4L), (4L, 3L), (2L, 3L), (2L, 1L)
     )).toDF(SRC, DST)
     val g = GraphFrame(vertices, edges)
     val components = g.connectedComponents.run()


### PR DESCRIPTION
When a vertex (e.g., 1) is the smallest among its neighbors (e.g., 2, 3, 4), we didn't exclude the record `(1, 2)` from the output of `minNbrs`. The bug was reported by @blendmaster in #208.

Closes #208 