### PR TITLE
[#209] use sbt-spark-package 0.2.6 to fix python excludes issue

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // You may use this file to add plugin dependencies for sbt.
 resolvers += "Spark Packages repo" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 
 // scalacOptions in (Compile,doc) := Seq("-groups", "-implicits")
 


### PR DESCRIPTION
Upgrade sbt-spark-package plugin version, so files under "python/graphframes/lib/" are included in the assembly jar. The upstream patch can be found at https://github.com/databricks/sbt-spark-package/pull/34. Manually verified that "python/graphframes/lib/*" were in the assembly jar.

Closes #209