### PR TITLE
Make edgeStorageLevel and vertexStorageLevel configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 jdk:
-  - oraclejdk7 # openJDK crashes sometimes
+  - openjdk7 # openJDK crashes sometimes
 
 sudo: required
 

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -280,7 +280,8 @@ class GraphFrame(object):
             .run()
         return DataFrame(jdf, self._sqlContext)
 
-    def labelPropagation(self, maxIter):
+    def labelPropagation(self, maxIter, intermediateVertexStorageLevel = StorageLevel.MEMORY_ONLY, 
+                         intermediateEdgeStorageLevel = StorageLevel.MEMORY_ONLY):
         """
         Runs static label propagation for detecting communities in networks.
 
@@ -289,7 +290,13 @@ class GraphFrame(object):
         :param maxIter: the number of iterations to be performed
         :return: DataFrame with new vertices column "label"
         """
-        jdf = self._jvm_graph.labelPropagation().maxIter(maxIter).run()
+
+        javaVertexStorageLevel = self._sc._getJavaStorageLevel(intermediateVertexStorageLevel)
+        javaEdgeStorageLevel = self._sc._getJavaStorageLevel(intermediateVertexStorageLevel)
+        jdf = self._jvm_graph.labelPropagation().maxIter(maxIter) \
+            .setIntermediateVertexStorageLevel(javaVertexStorageLevel) \
+            .setIntermediateEdgeStorageLevel(javaEdgeStorageLevel) \
+            .run()
         return DataFrame(jdf, self._sqlContext)
 
     def pageRank(self, resetProbability = 0.15, sourceId = None, maxIter = None,

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -322,7 +322,6 @@ class GraphFrameLibTest(GraphFrameTestCase):
 
     def test_page_rank_intermediate_storage_level(self):
         g = self._graph("friends")
-        #page rank - iterations
         pr = g.pageRank(maxIter=1)
         expected_vertex = pr.vertices.collect()
         expected_edge = pr.edges.collect()
@@ -330,17 +329,6 @@ class GraphFrameLibTest(GraphFrameTestCase):
         for vLabel in levels:
             for eLabel in levels:
                 pr_out = g.pageRank(maxIter=1, intermediateVertexStorageLevel=vLabel, intermediateEdgeStorageLevel=eLabel)
-                self.assertEqual(pr_out.vertices.collect(), expected_vertex)
-                self.assertEqual(pr_out.edges.collect(), expected_edge)
-
-        #page rank - convergence
-        pr = g.pageRank(tol=0.9)
-        expected_vertex = pr.vertices.collect()
-        expected_edge = pr.edges.collect()
-        levels = [StorageLevel.DISK_ONLY, StorageLevel.MEMORY_AND_DISK]
-        for vLabel in levels:
-            for eLabel in levels:
-                pr_out = g.pageRank(tol=0.9, intermediateVertexStorageLevel=vLabel, intermediateEdgeStorageLevel=eLabel)
                 self.assertEqual(pr_out.vertices.collect(), expected_vertex)
                 self.assertEqual(pr_out.edges.collect(), expected_edge)
 
@@ -356,6 +344,9 @@ class GraphFrameLibTest(GraphFrameTestCase):
         self._hasCols(pr, vcols=['id', 'pageranks'], ecols=['src', 'dst', 'weight'])
 
     def test_parallel_personalized_page_rank_intermediate_storage_level(self):
+        if GraphFrameTestUtils.spark_at_least_of_version("2.2"):
+            self.skipTest("in Spark 2.2, sourceIds must be smaller than Int.MaxValue \
+                which might not be the case for LONG_ID in graph.indexedVertices")
         if not GraphFrameTestUtils.spark_at_least_of_version("2.1"):
             self.skipTest("Parallel Personalized PageRank is only available in Apache Spark 2.1+")
         g = self._graph("friends")

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -356,6 +356,8 @@ class GraphFrameLibTest(GraphFrameTestCase):
         self._hasCols(pr, vcols=['id', 'pageranks'], ecols=['src', 'dst', 'weight'])
 
     def test_parallel_personalized_page_rank_intermediate_storage_level(self):
+        if not GraphFrameTestUtils.spark_at_least_of_version("2.1"):
+            self.skipTest("Parallel Personalized PageRank is only available in Apache Spark 2.1+")
         g = self._graph("friends")
         sourceIds = ["a", "b"]
         ppr = g.parallelPersonalizedPageRank(maxIter=1, sourceIds=sourceIds)

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -526,6 +526,30 @@ class GraphFrame private(
   }
 
   /**
+    * creates a new GraphX `Graph` from the cachedTopologyGraphX `Graph` with the vertex and edge storage levels passed
+    * in this method
+    * @param vertexStorageLevel vertex storage level set in the returned GraphX `Graph` instance
+    * @param edgeStorageLevel edge storage level set in the returned GraphX `Graph` instance
+    * @return a copy of the cachedTopologyGraphX `Graph` instance with the provided storage levels or the
+    *         cachedTopologyGraphX instance if the default storage level values are provided (``MEMORY_ONLY`` in both cases)
+    *
+    */
+  private[graphframes] def cachedTopologyGraphXWithStorageLevel(
+      vertexStorageLevel: StorageLevel,
+      edgeStorageLevel: StorageLevel) =
+    if(vertexStorageLevel == StorageLevel.MEMORY_ONLY && edgeStorageLevel == StorageLevel.MEMORY_ONLY) {
+      cachedTopologyGraphX
+    } else {
+      Graph(
+        vertices = cachedTopologyGraphX.vertices,
+        edges = cachedTopologyGraphX.edges,
+        defaultVertexAttr = null.asInstanceOf[Unit],
+        vertexStorageLevel = vertexStorageLevel,
+        edgeStorageLevel = edgeStorageLevel
+      )
+    }
+
+  /**
    * A cached conversion of this graph to the GraphX structure, with the data stored for each edge and vertex.
    */
   @transient private lazy val cachedGraphX: Graph[Row, Row] = { toGraphX }

--- a/src/test/scala/org/graphframes/lib/PageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PageRankSuite.scala
@@ -55,9 +55,11 @@ class PageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(prConv.getIntermediateVertexStorageLevel === StorageLevel.MEMORY_ONLY)
     assert(prConv.getIntermediateEdgeStorageLevel === StorageLevel.MEMORY_ONLY)
 
+    val graphIter = prIter.run()
+    val graphConv = prConv.run()
     val expected = Seq(
-      (prIter.run().vertices.collect(), prIter.run().edges.collect()),
-      (prConv.run().vertices.collect(), prConv.run().edges.collect()))
+      (graphIter.vertices.collect(), graphIter.edges.collect()),
+      (graphConv.vertices.collect(), graphConv.edges.collect()))
 
     val levels = Seq(StorageLevel.DISK_ONLY, StorageLevel.MEMORY_AND_DISK)
     for(vLevel <- levels; eLevel <- levels; prExpected <- Seq(prIter, prConv).zip(expected)) {

--- a/src/test/scala/org/graphframes/lib/PageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PageRankSuite.scala
@@ -19,7 +19,7 @@ package org.graphframes.lib
 
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
-
+import org.apache.spark.storage.StorageLevel
 import org.graphframes.examples.Graphs
 import org.graphframes.{GraphFrameTestSparkContext, SparkFunSuite, TestUtils}
 
@@ -45,5 +45,31 @@ class PageRankSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val gRank = results.vertices.filter(col("id") === "g").select("pagerank").first().getDouble(0)
     assert(gRank === 0.0,
       s"User g (Gabby) doesn't connect with a. So its pagerank should be 0 but we got $gRank.")
+  }
+
+  test("intermediate storage levels") {
+    val prIter = Graphs.friends.pageRank.maxIter(1)
+    val prConv = Graphs.friends.pageRank.tol(0.9)
+    assert(prIter.getIntermediateVertexStorageLevel === StorageLevel.MEMORY_ONLY)
+    assert(prIter.getIntermediateEdgeStorageLevel === StorageLevel.MEMORY_ONLY)
+    assert(prConv.getIntermediateVertexStorageLevel === StorageLevel.MEMORY_ONLY)
+    assert(prConv.getIntermediateEdgeStorageLevel === StorageLevel.MEMORY_ONLY)
+
+    val expected = Seq(
+      (prIter.run().vertices.collect(), prIter.run().edges.collect()),
+      (prConv.run().vertices.collect(), prConv.run().edges.collect()))
+
+    val levels = Seq(StorageLevel.DISK_ONLY, StorageLevel.MEMORY_AND_DISK)
+    for(vLevel <- levels; eLevel <- levels; prExpected <- Seq(prIter, prConv).zip(expected)) {
+      val graph = prExpected._1
+        .setIntermediateVertexStorageLevel(vLevel)
+        .setIntermediateEdgeStorageLevel(eLevel)
+        .run()
+
+      assert(graph.vertices.collect() === prExpected._2._1)
+      assert(graph.edges.collect() === prExpected._2._2)
+      assert(prExpected._1.getIntermediateVertexStorageLevel === vLevel)
+      assert(prExpected._1.getIntermediateEdgeStorageLevel === eLevel)
+    }
   }
 }

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -111,7 +111,9 @@ class ParallelPersonalizedPageRankSuite extends SparkFunSuite with GraphFrameTes
     assert(ppr.getIntermediateVertexStorageLevel === StorageLevel.MEMORY_ONLY)
     assert(ppr.getIntermediateEdgeStorageLevel === StorageLevel.MEMORY_ONLY)
 
-    if (isLaterVersion("2.1")) {
+    if (isLaterVersion("2.2")) {
+      intercept[java.lang.IllegalArgumentException] { ppr.run() }
+    } else if (isLaterVersion("2.1")) {
       val graph = ppr.run()
       val expected = (graph.vertices.collect(), graph.edges.collect())
 

--- a/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ParallelPersonalizedPageRankSuite.scala
@@ -107,20 +107,24 @@ class ParallelPersonalizedPageRankSuite extends SparkFunSuite with GraphFrameTes
     assert(ppr.getIntermediateVertexStorageLevel === StorageLevel.MEMORY_ONLY)
     assert(ppr.getIntermediateEdgeStorageLevel === StorageLevel.MEMORY_ONLY)
 
-    val graph = ppr.run()
-    val expected = (graph.vertices.collect(), graph.edges.collect())
+    if (isLaterVersion("2.1")) {
+      val graph = ppr.run()
+      val expected = (graph.vertices.collect(), graph.edges.collect())
 
-    val levels = Seq(StorageLevel.DISK_ONLY, StorageLevel.MEMORY_AND_DISK)
-    for (vLevel <- levels; eLevel <- levels) {
-      val graph = ppr
-        .setIntermediateVertexStorageLevel(vLevel)
-        .setIntermediateEdgeStorageLevel(eLevel)
-        .run()
+      val levels = Seq(StorageLevel.DISK_ONLY, StorageLevel.MEMORY_AND_DISK)
+      for (vLevel <- levels; eLevel <- levels) {
+        val graph = ppr
+          .setIntermediateVertexStorageLevel(vLevel)
+          .setIntermediateEdgeStorageLevel(eLevel)
+          .run()
 
-      assert(graph.vertices.collect() === expected._1)
-      assert(graph.edges.collect() === expected._2)
-      assert(ppr.getIntermediateVertexStorageLevel === vLevel)
-      assert(ppr.getIntermediateEdgeStorageLevel === eLevel)
+        assert(graph.vertices.collect() === expected._1)
+        assert(graph.edges.collect() === expected._2)
+        assert(ppr.getIntermediateVertexStorageLevel === vLevel)
+        assert(ppr.getIntermediateEdgeStorageLevel === eLevel)
+      }
+    } else {
+      intercept[NotImplementedError] { ppr.run() }
     }
   }
 


### PR DESCRIPTION
This PR addresses issue #219 The properties ``intermediateVertexStorageLevel`` and ``intermediateEdgeStorageLevel`` with their respective getters and setters were added to the classes that represent graph algorithms with a GraphX implementation. These 2 properties are used to change the storage level of the GraphX instance referenced by ``GraphFrame.cachedTopologyGraphX`` before calling the GraphX algorithm implementation.

In the special case of ConnectedComponent class, the properties were named ``graphxVertexStorageLevel`` and ``graphxEdgeStorageLevel`` to differentiate them with the property ``intermediateStorageLevel`` used in the graphframe implementation of this algorithm. Also the Python api of ConnectedComponent was modified to include a similar feature implemented in #213 only to the Scala api

These changes were applied to both the Scala and Python apis
