### PR TITLE
PageRank docs updated

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -642,12 +642,12 @@ result.select("id", "label").show()
 
 ## PageRank
 
+There are two implementations of PageRank.
 
-There are two implementations of PageRank. Both of them use the `org.apache.spark.graphx.Pregel` interface,
-however, they differ on the stopping condition.
-
-* The first one runs PageRank for a fixed number of iterations and this can be run by setting `maxIter`.
-* The second implementation runs PageRank until convergence and this can be run by setting `tol`.
+* The first one uses the `org.apache.spark.graphx.graph` interface with `aggregateMessages` and runs
+PageRank for a fixed number of iterations. This can be executed by setting `maxIter`.
+* The second implementation uses the `org.apache.spark.graphx.Pregel` interface and runs PageRank until
+convergence and this can be run by setting `tol`.
 
 Both implementations support non-personalized and personalized PageRank, where setting a `sourceId`
 personalizes the results for that vertex.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -642,12 +642,12 @@ result.select("id", "label").show()
 
 ## PageRank
 
-There are two implementations of PageRank.
 
-* The first implementation uses the standalone `GraphFrame` interface and runs PageRank
- for a fixed number of iterations.  This can be run by setting `maxIter`.
-* The second implementation uses the `org.apache.spark.graphx.Pregel` interface and runs PageRank
-  until convergence.  This can be run by setting `tol`.
+There are two implementations of PageRank. Both of them use the `org.apache.spark.graphx.Pregel` interface,
+however, they differ on the stopping condition.
+
+* The first one runs PageRank for a fixed number of iterations and this can be run by setting `maxIter`.
+* The second implementation runs PageRank until convergence and this can be run by setting `tol`.
 
 Both implementations support non-personalized and personalized PageRank, where setting a `sourceId`
 personalizes the results for that vertex.

--- a/src/main/scala/org/graphframes/lib/PageRank.scala
+++ b/src/main/scala/org/graphframes/lib/PageRank.scala
@@ -19,14 +19,14 @@ package org.graphframes.lib
 
 import org.apache.spark.graphx.{lib => graphxlib}
 
-import org.graphframes.{GraphFrame, Logging}
+import org.graphframes.GraphFrame
 
 /**
- * PageRank algorithm implementation. There are two implementations of PageRank. Both of them use
- * the `org.apache.spark.graphx.Pregel` interface, however, they differ on the stopping condition.
+ * PageRank algorithm implementation. There are two implementations of PageRank.
  *
- * The first one runs PageRank for a fixed number of iterations and this can be run by setting `maxIter`.
- * Conceptually, the algorithm does the following:
+ * The first one uses the `org.apache.spark.graphx.graph` interface with `aggregateMessages` and runs
+ * PageRank for a fixed number of iterations. This can be executed by setting `maxIter`. Conceptually,
+ * the algorithm does the following:
  * {{{
  * var PR = Array.fill(n)( 1.0 )
  * val oldPR = Array.fill(n)( 1.0 )
@@ -38,8 +38,8 @@ import org.graphframes.{GraphFrame, Logging}
  * }
  * }}}
  *
- * The second implementation runs PageRank until convergence and this can be run by setting `tol`.
- * Conceptually, the algorithm does the following:
+ * The second implementation uses the `org.apache.spark.graphx.Pregel` interface and runs PageRank until
+ * convergence and this can be run by setting `tol`. Conceptually, the algorithm does the following:
  * {{{
  * var PR = Array.fill(n)( 1.0 )
  * val oldPR = Array.fill(n)( 0.0 )

--- a/src/main/scala/org/graphframes/lib/PageRank.scala
+++ b/src/main/scala/org/graphframes/lib/PageRank.scala
@@ -22,10 +22,11 @@ import org.apache.spark.graphx.{lib => graphxlib}
 import org.graphframes.{GraphFrame, Logging}
 
 /**
- * PageRank algorithm implementation. There are two implementations of PageRank.
+ * PageRank algorithm implementation. There are two implementations of PageRank. Both of them use
+ * the `org.apache.spark.graphx.Pregel` interface, however, they differ on the stopping condition.
  *
- * The first implementation uses the standalone [[GraphFrame]] interface and runs PageRank
- * for a fixed number of iterations.  This can be run by setting `maxIter`.
+ * The first one runs PageRank for a fixed number of iterations and this can be run by setting `maxIter`.
+ * Conceptually, the algorithm does the following:
  * {{{
  * var PR = Array.fill(n)( 1.0 )
  * val oldPR = Array.fill(n)( 1.0 )
@@ -37,9 +38,8 @@ import org.graphframes.{GraphFrame, Logging}
  * }
  * }}}
  *
- * The second implementation uses the `org.apache.spark.graphx.Pregel` interface and runs PageRank
- * until convergence.  This can be run by setting `tol`.
- *
+ * The second implementation runs PageRank until convergence and this can be run by setting `tol`.
+ * Conceptually, the algorithm does the following:
  * {{{
  * var PR = Array.fill(n)( 1.0 )
  * val oldPR = Array.fill(n)( 0.0 )


### PR DESCRIPTION
A solution to issue #233

## **Current situation**
PageRank scala docs and user guide say that the implementation which runs for a fixed number of iterations (through the `maxIter` parameter) uses the Graphframes interface when in fact it uses the graphX's Pregel one.

## **What was done?**
Both docs were fixed to match what the code does.