### PR TITLE
Support Spark 2.2 & 2.3 + Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,14 @@
 val sparkVer = sys.props.getOrElse("spark.version", "2.1.0")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
-  case "1.6" => "2.10.6"
-  case "2.0" => "2.11.8"
-  case "2.1" => "2.11.8"
+  case "1.6" => "2.10.7"
+  case "2.0" | "2.1" | "2.2" | "2.3" => "2.11.11"
   case _ => throw new IllegalArgumentException(s"Unsupported Spark version: $sparkVer.")
 }
 val scalaVer = sys.props.getOrElse("scala.version", defaultScalaVer)
 val defaultScalaTestVer = scalaVer match {
   case s if s.startsWith("2.10") => "2.0"
-  case s if s.startsWith("2.11") => "2.2.6" // scalatest_2.11 does not have 2.0 published
+  case s if s.startsWith("2.11") => "3.0.5" // scalatest_2.11 does not have 2.0 published
 }
 
 sparkVersion := sparkVer


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support to Spark 2.2 & 2.3. Update scalatest version.

## How was this patch tested?

`build/sbt clean assembly -Dspark.version=2.3.1`