### PR TITLE
Fix negation in motif finding

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -266,6 +266,9 @@ Restrictions:
 More complex queries, such as queries which operate on vertex or edge attributes,
 can be expressed by applying filters to the result `DataFrame`.
 
+This can return duplicate rows.  E.g., a query `"(u)-[]->()"` will return a result for each
+matching edge, even if those edges share the same vertex `u`.
+
 <div class="codetabs">
 
 <div data-lang="scala"  markdown="1">

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -241,11 +241,16 @@ DSL for expressing structural patterns:
       `GraphFrame.vertices`. Similarly, an edge `e` in a motif will produce a column "e"
       in the result `DataFrame` with sub-fields equivalent to the schema (columns) of
       `GraphFrame.edges`.
+  * Be aware that names do *not* identify *distinct* elements: two elements with different
+      names may refer to the same graph element.  For example, in the motif
+      `"(a)-[e]->(b); (b)-[e2]->(c)"`, the names `a` and `c` could refer to the same vertex.
+      To restrict named elements to be distinct vertices or edges, use post-hoc filters
+      such as `resultDataframe.filter("a.id != c.id")`.
 * It is acceptable to omit names for vertices or edges in motifs when not needed.
    E.g., `"(a)-[]->(b)"` expresses an edge between vertices `a,b` but does not assign a name
    to the edge.  There will be no column for the anonymous edge in the result `DataFrame`.
    Similarly, `"(a)-[e]->()"` indicates an out-edge of vertex `a` but does not name
-   the destination vertex.
+   the destination vertex.  These are called *anonymous* vertices and edges.
 * An edge can be negated to indicate that the edge should *not* be present in the graph.
   E.g., `"(a)-[]->(b); !(b)-[]->(a)"` finds edges from `a` to `b` for which there is *no*
   edge from `b` to `a`.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,6 +255,14 @@ DSL for expressing structural patterns:
   E.g., `"(a)-[]->(b); !(b)-[]->(a)"` finds edges from `a` to `b` for which there is *no*
   edge from `b` to `a`.
 
+Restrictions:
+
+* Motifs are not allowed to contain edges without any named elements: `"()-[]->()"` and
+    `"!()-[]->()"` are prohibited terms.
+* Motifs are not allowed to contain named edges within negated terms (since these named
+    edges would never appear within results).  E.g., `"!(a)-[ab]->(b)"` is invalid, but
+    `"!(a)-[]->(b)"` is valid.
+
 More complex queries, such as queries which operate on vertex or edge attributes,
 can be expressed by applying filters to the result `DataFrame`.
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -839,7 +839,7 @@ object GraphFrame extends Serializable with Logging {
           val eRen = nestE(name)
           val dstV = nestV(dstName)
           (Some(maybeCrossJoin(prev, eRen)
-            .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)), "left_outer")),
+            .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
             prevNames :+ name :+ dstName)
         }
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -330,7 +330,9 @@ class GraphFrame private(
     val extraPositivePatterns = namedVerticesOnlyInNegatedTerms.map(v => NamedVertex(v))
     val augmentedPatterns = extraPositivePatterns ++ patterns
     val df = findSimple(augmentedPatterns)
-    enforceColumnOrder(df, Pattern.findNamedElementsInOrder(patterns, includeEdges = true))
+
+    val names = Pattern.findNamedElementsInOrder(patterns, includeEdges = true)
+    if (names.isEmpty) df else df.select(names.head, names.tail : _*)
   }
 
   // ======================== Other queries ===================================
@@ -915,13 +917,5 @@ object GraphFrame extends Serializable with Logging {
     require(value >= 0)
     _broadcastThreshold = value
     this
-  }
-
-  /**
-   * Return the given DataFrame with columns in a given order.
-   * @param names This method assumes that names is exactly the set of columns in the DataFrame.
-   */
-  private[graphframes] def enforceColumnOrder(df: DataFrame, names: Seq[String]): DataFrame = {
-    if (names.isEmpty) df else df.select(names.head, names.tail : _*)
   }
 }

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -320,6 +320,9 @@ class GraphFrame private(
    * More complex queries, such as queries which operate on vertex or edge attributes,
    * can be expressed by applying filters to the result `DataFrame`.
    *
+   * This can return duplicate rows.  E.g., a query `"(u)-[]->()"` will return a result for each
+   * matching edge, even if those edges share the same vertex `u`.
+   *
    * @param pattern  Pattern specifying a motif to search for.
    * @return  `DataFrame` containing all instances of the motif.
    * @group motif

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -878,7 +878,7 @@ object GraphFrame extends Serializable with Logging {
               .join(srcV, eRen(eSrcId(name)) === srcV(vId(srcName)))),
               prevNames :+ srcName :+ name)
 
-          case (false, false) =>
+          case (false, false) if srcName != dstName =>
             val eRen = nestE(name)
             val srcV = nestV(srcName)
             val dstV = nestV(dstName)
@@ -887,6 +887,15 @@ object GraphFrame extends Serializable with Logging {
               .join(dstV, eRen(eDstId(name)) === dstV(vId(dstName)))),
               prevNames :+ srcName :+ name :+ dstName)
           // TODO: expose the plans from joining these in the opposite order
+
+          case (false, false) if srcName == dstName =>
+            val eRen = nestE(name)
+            val srcV = nestV(srcName)
+            (Some(maybeCrossJoin(prev, eRen)
+              .join(srcV,
+                eRen(eSrcId(name)) === srcV(vId(srcName)) &&
+                  eRen(eDstId(name)) === srcV(vId(srcName)))),
+              prevNames :+ srcName :+ name)
         }
 
       case AnonymousEdge(src, dst) =>

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -326,6 +326,10 @@ class GraphFrame private(
    */
   def find(pattern: String): DataFrame = {
     val patterns = Pattern.parse(pattern)
+
+    // For each named vertex appearing only in a negated term, we augment the positive terms
+    // with the vertex as a standalone term `(v)`.
+    // See https://github.com/graphframes/graphframes/issues/276
     val namedVerticesOnlyInNegatedTerms = Pattern.findNamedVerticesOnlyInNegatedTerms(patterns)
     val extraPositivePatterns = namedVerticesOnlyInNegatedTerms.map(v => NamedVertex(v))
     val augmentedPatterns = extraPositivePatterns ++ patterns

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -296,19 +296,21 @@ class GraphFrame private(
    *       [[GraphFrame.vertices]]. Similarly, an edge `e` in a motif will produce a column "e"
    *       in the result `DataFrame` with sub-fields equivalent to the schema (columns) of
    *       [[GraphFrame.edges]].
+   *     - Be aware that names do *not* identify *distinct* elements: two elements with different
+   *       names may refer to the same graph element.  For example, in the motif
+   *       `"(a)-[e]->(b); (b)-[e2]->(c)"`, the names `a` and `c` could refer to the same vertex.
+   *       To restrict named elements to be distinct vertices or edges, use post-hoc filters
+   *       such as `resultDataframe.filter("a.id != c.id")`.
    *  - It is acceptable to omit names for vertices or edges in motifs when not needed.
    *    E.g., `"(a)-[]->(b)"` expresses an edge between vertices `a,b` but does not assign a name
    *    to the edge.  There will be no column for the anonymous edge in the result `DataFrame`.
    *    Similarly, `"(a)-[e]->()"` indicates an out-edge of vertex `a` but does not name
-   *    the destination vertex.
+   *    the destination vertex.  These are called *anonymous* vertices and edges.
    *  - An edge can be negated to indicate that the edge should *not* be present in the graph.
    *    E.g., `"(a)-[]->(b); !(b)-[]->(a)"` finds edges from `a` to `b` for which there is *no*
    *    edge from `b` to `a`.
    *
-   * Notes and restrictions:
-   *  - Different names for vertices do NOT indicate that the vertices are distinct.
-   *    E.g., `"(a)-[]->(b)"` could match a self-loop with `a,b` being the same vertex.
-   *    Enforce distinction via post-hoc filters.
+   * Restrictions:
    *  - Motifs are not allowed to contain edges without any named elements: `"()-[]->()"` and
    *    `"!()-[]->()"` are prohibited terms.
    *  - Motifs are not allowed to contain named edges within negated terms (since these named

--- a/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -142,7 +142,6 @@ private[graphframes] object Pattern {
   private[graphframes]
   def findNamedElementsInOrder(patterns: Seq[Pattern], includeEdges: Boolean): Seq[String] = {
     val elementSet = mutable.LinkedHashSet.empty[String]
-
     def findNamedElementsHelper(pattern: Pattern): Unit = pattern match {
       case Negation(child) =>
         findNamedElementsHelper(child)

--- a/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -142,6 +142,7 @@ private[graphframes] object Pattern {
   private[graphframes]
   def findNamedElementsInOrder(patterns: Seq[Pattern], includeEdges: Boolean): Seq[String] = {
     val elementSet = mutable.LinkedHashSet.empty[String]
+
     def findNamedElementsHelper(pattern: Pattern): Unit = pattern match {
       case Negation(child) =>
         findNamedElementsHelper(child)

--- a/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -87,6 +87,10 @@ private[graphframes] object Pattern {
           throw new InvalidParseException(s"Motif reused name '$name' for both a vertex and " +
             s"an edge, which is not allowed.")
         }
+        if (edgeNames.contains(name)) {
+          throw new InvalidParseException(s"Motif reused name '$name' for multiple edges, " +
+            s"which is not allowed.")
+        }
         edgeNames += name
         addVertex(src)
         addVertex(dst)
@@ -116,7 +120,10 @@ private[graphframes] object Pattern {
         addEdge(e)
       case e @ NamedEdge(_, _, _) =>
         addEdge(e)
-      case AnonymousVertex => // ok
+      case AnonymousVertex =>
+        throw new InvalidParseException("Motif finding does not allow a lone anonymous vertex " +
+          "\"()\" in a motif.  Users can check for the existence of vertices in the graph " +
+          "using the vertices DataFrame.")
       case v @ NamedVertex(_) =>
         addVertex(v)
     }

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -291,4 +291,14 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     GraphFrame.setBroadcastThreshold(defaultThreshold)
   }
+
+  test("enforceColumnOrder") {
+    import GraphFrame.enforceColumnOrder
+    assert(enforceColumnOrder(edges, Seq("src", "action", "dst")).columns ===
+      Array("src", "action", "dst"))
+    assert(enforceColumnOrder(edges, Seq("dst", "src", "action")).columns ===
+      Array("dst", "src", "action"))
+    assert(enforceColumnOrder(edges.where("src = 1234567890"), Seq.empty[String]).columns ===
+      Array.empty[String])
+  }
 }

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -291,14 +291,4 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     GraphFrame.setBroadcastThreshold(defaultThreshold)
   }
-
-  test("enforceColumnOrder") {
-    import GraphFrame.enforceColumnOrder
-    assert(enforceColumnOrder(edges, Seq("src", "action", "dst")).columns ===
-      Array("src", "action", "dst"))
-    assert(enforceColumnOrder(edges, Seq("dst", "src", "action")).columns ===
-      Array("dst", "src", "action"))
-    assert(enforceColumnOrder(edges.where("src = 1234567890"), Seq.empty[String]).columns ===
-      edges.columns)
-  }
 }

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -299,6 +299,6 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(enforceColumnOrder(edges, Seq("dst", "src", "action")).columns ===
       Array("dst", "src", "action"))
     assert(enforceColumnOrder(edges.where("src = 1234567890"), Seq.empty[String]).columns ===
-      Array.empty[String])
+      edges.columns)
   }
 }

--- a/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -423,10 +423,8 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   /* ================================= Invalid queries =================================== */
 
-  // TODO: MORE SPECIFIC EXCEPTIONS?
-
   test("Disallow empty term ()-[]->()") {
-    intercept[Exception] {
+    intercept[InvalidParseException] {
       g.find("()-[]->()")
     }
   }
@@ -440,6 +438,15 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     }
     intercept[InvalidParseException] {
       g.find("(u)-[ab]->(v); !(a)-[ab]->(b)")
+    }
+  }
+
+  test("Disallow using the same name for both a vertex and an edge") {
+    intercept[InvalidParseException] {
+      g.find("(a)-[a]->(b)")
+    }
+    intercept[InvalidParseException] {
+      g.find("(a)-[]->(b); (c)-[a]->(d)")
     }
   }
 

--- a/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -162,6 +162,16 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(selfLoops.columns === Array("a"))
     val res = selfLoops.select("a.id").collect().toSet
     compareResultToExpected(res, Set(Row(1L), Row(3L)))
+
+    val selfLoops2 = myG.find("(a)-[]->(b); (a)-[]->(a)")
+    assert(selfLoops2.columns === Array("a", "b"))
+    val res2 = selfLoops2.select("a.id", "b.id")
+      .where("a.id != b.id")
+      .collect().toSet
+    compareResultToExpected(res2, Set(
+      Row(1L, 0L),
+      Row(1L, 2L)
+    ))
   }
 
   /* ======================== Multiple-edge queries without negated terms ===================== */

--- a/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -46,7 +46,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       (3L, "d", "f"))).toDF("id", "attr", "gender")
     e = sqlContext.createDataFrame(List(
       (0L, 1L, "friend"),
-      (1L, 0L, "friend"),
+      (1L, 0L, "follow"),
       (1L, 2L, "friend"),
       (2L, 3L, "follow"),
       (2L, 0L, "unknown"))).toDF("src", "dst", "relationship")
@@ -58,6 +58,22 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     e = null
     g = null
     super.afterAll()
+  }
+
+  private def compareResultToExpected[A](result: Set[A], expected: Set[A]): Unit = {
+    if (result !== expected) {
+      throw new AssertionError("result !== expected.\n" +
+        s"Result contained additional values: ${result.diff(expected)}\n" +
+        s"Expected contained additional values: ${expected.diff(result)}\n" +
+        s"Result: $result\n" +
+        s"Expected: $expected")
+    }
+  }
+
+  test("test compareResultToExpected") {
+    intercept[AssertionError] {
+      compareResultToExpected(Set(1, 2), Set(2, 3))
+    }
   }
 
   test("empty query should return nothing") {
@@ -77,8 +93,8 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val vertices = g.find("(a)")
 
     assert(vertices.columns === Array("a"))
-    assert(vertices.select("a.id", "a.attr").collect().toSet
-      === v.select("id", "attr").collect().toSet)
+    val res = vertices.select("a.id", "a.attr").collect().toSet
+    compareResultToExpected(res, v.select("id", "attr").collect().toSet)
   }
 
   /* =========================== Single-edge queries without negated terms ===================== */
@@ -87,7 +103,8 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val triplets = g.find("(u)-[]->(v)")
 
     assert(triplets.columns === Array("u", "v"))
-    assert(triplets.select("u.id", "u.attr", "v.id", "v.attr").collect().toSet === Set(
+    val res = triplets.select("u.id", "u.attr", "v.id", "v.attr").collect().toSet
+    compareResultToExpected(res, Set(
       Row(0L, "a", 1L, "b"),
       Row(1L, "b", 0L, "a"),
       Row(1L, "b", 2L, "c"),
@@ -100,11 +117,12 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val triplets = g.find("(u)-[uv]->(v)")
 
     assert(triplets.columns === Array("u", "uv", "v"))
-    assert(triplets.select("u.id", "u.attr", "uv.src", "uv.dst", "uv.relationship",
+    val res = triplets.select("u.id", "u.attr", "uv.src", "uv.dst", "uv.relationship",
       "v.id", "v.attr")
-      .collect().toSet === Set(
+      .collect().toSet
+    compareResultToExpected(res, Set(
       Row(0L, "a", 0L, 1L, "friend", 1L, "b"),
-      Row(1L, "b", 1L, 0L, "friend", 0L, "a"),
+      Row(1L, "b", 1L, 0L, "follow", 0L, "a"),
       Row(1L, "b", 1L, 2L, "friend", 2L, "c"),
       Row(2L, "c", 2L, 3L, "follow", 3L, "d"),
       Row(2L, "c", 2L, 0L, "unknown", 0L, "a")
@@ -130,7 +148,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(triplets.columns === Array("uv"))
     val res = triplets.select("uv.src", "uv.dst", "uv.relationship").collect().toSet
     val expected = e.select("src", "dst", "relationship").collect().toSet
-    assert(res === expected)
+    compareResultToExpected(res, expected)
   }
 
   /* ======================== Multiple-edge queries without negated terms ===================== */
@@ -141,7 +159,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(triangles.columns === Array("a", "b", "c"))
     val res = triangles.select("a.id", "b.id", "c.id")
       .collect().toSet
-    assert(res === Set(
+    compareResultToExpected(res, Set(
       Row(0L, 1L, 2L),
       Row(2L, 0L, 1L),
       Row(1L, 2L, 0L)
@@ -159,7 +177,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val cd = e.select(col("src").alias("c"), col("dst").alias("d"))
     val expected = ab.crossJoin(cd)
       .collect().toSet
-    assert(res === expected)
+    compareResultToExpected(res, expected)
     val numEdges = e.count()
     assert(expected.size === numEdges * numEdges)
   }
@@ -172,7 +190,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(edges.columns === Array("a", "b"))
     val res = edges.select("a.id", "b.id")
       .collect().toSet
-    assert(res === Set(
+    compareResultToExpected(res, Set(
       Row(1L, 2L),
       Row(2L, 0L),
       Row(2L, 3L)
@@ -197,7 +215,11 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       .select("u.id", "v.id", "w.id")
       .collect().toSet
 
-    assert(fof === Set(Row(1L, 2L, 3L)))
+    compareResultToExpected(fof, Set(
+      Row(1L, 0L, 1L),
+      Row(0L, 1L, 0L),
+      Row(1L, 2L, 3L)
+    ))
   }
 
   /* ========== 1 named vertex grounding a negated term to non-negated terms =============== */
@@ -208,14 +230,19 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(edges.columns === Array("a", "b", "c"))
     val res = edges.select("a.id", "b.id", "c.id")
       .collect().toSet
-    assert(res === Set(
+    compareResultToExpected(res, Set(
+      Row(0L, 1L, 1L),
       Row(0L, 1L, 3L),
+      Row(1L, 0L, 0L),
       Row(1L, 0L, 2L),
       Row(1L, 0L, 3L),
       Row(1L, 2L, 1L),
+      Row(1L, 2L, 2L),
       Row(2L, 3L, 0L),
       Row(2L, 3L, 1L),
       Row(2L, 3L, 2L),
+      Row(2L, 3L, 3L),
+      Row(2L, 0L, 0L),
       Row(2L, 0L, 2L),
       Row(2L, 0L, 3L)
     ))
@@ -227,7 +254,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(edges.columns === Array("a", "b"))
     val res = edges.select("a.id", "b.id")
       .collect().toSet
-    assert(res === Set(
+    compareResultToExpected(res, Set(
       Row(2L, 3L)
     ))
   }
@@ -241,6 +268,10 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val res = edgePairs.select("a.id", "b.id", "c.id", "d.id")
       .collect().toSet
     val noEdges = sqlContext.createDataFrame(List(
+      (0L, 0L),
+      (1L, 1L),
+      (2L, 2L),
+      (3L, 3L),
       (0L, 2L),
       (0L, 3L),
       (1L, 3L),
@@ -253,7 +284,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       .crossJoin(noEdges)
       .select("a", "b", "c", "d")
       .collect().toSet
-    assert(res === expected)
+    compareResultToExpected(res, expected)
     assert(expected.size === noEdges.count() * e.count())  // make sure there are no duplicates
   }
 
@@ -270,7 +301,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       Row(2L, 3L, 3L),
       Row(2L, 0L, 3L)
     )
-    assert(res === expected)
+    compareResultToExpected(res, expected)
   }
 
   /* ======= Varying # of named vertices grounding a negated term to non-negated terms ========= */
@@ -287,12 +318,16 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       Row(0L, 1L, 3L),
       Row(1L, 0L, 2L),
       Row(1L, 0L, 3L),
-      Row(1L, 2L, 3L),
+      Row(1L, 2L, 1L),
+      Row(1L, 2L, 2L),
       Row(2L, 3L, 0L),
-      Row(2L, 3L, 1L),
+      Row(2L, 3L, 2L),
+      Row(2L, 3L, 3L),
+      Row(2L, 0L, 0L),
+      Row(2L, 0L, 2L),
       Row(2L, 0L, 3L)
     )
-    assert(res === expected)
+    compareResultToExpected(res, expected)
   }
 
   test("a->b, c, d with no edges a->c, c->d") {
@@ -300,19 +335,20 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     assert(edgePairs.columns === Array("a", "b", "c", "d"))
     val res = edgePairs.select("a.id", "b.id", "c.id", "d.id")
-      .where("a.id = 0 OR a.id = 1")  // just check a subset of the result for brevity
+      .where("a.id = 0 AND a.id != b.id")  // check subset for brevity
       .collect().toSet
     val expected = Set(
       Row(0L, 1L, 0L, 0L),
       Row(0L, 1L, 0L, 2L),
       Row(0L, 1L, 0L, 3L),
-      Row(1L, 0L, 1L, 1L),
-      Row(1L, 0L, 3L, 0L),
-      Row(1L, 0L, 3L, 1L),
-      Row(1L, 0L, 3L, 2L),
-      Row(1L, 0L, 3L, 3L)
+      Row(0L, 1L, 2L, 1L),
+      Row(0L, 1L, 2L, 2L),
+      Row(0L, 1L, 3L, 0L),
+      Row(0L, 1L, 3L, 1L),
+      Row(0L, 1L, 3L, 2L),
+      Row(0L, 1L, 3L, 3L)
     )
-    assert(res === expected)
+    compareResultToExpected(res, expected)
   }
 
   /* ============================== 0 non-negated terms ============================== */
@@ -321,22 +357,25 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     val res = g.find("!(v)-[]->()")
       .select("v.id")
       .collect().toSet
-    assert(res === Set(Row(3L)))
+    compareResultToExpected(res, Set(Row(3L)))
   }
 
   test("query without non-negated terms, with two named vertices") {
     val res = g.find("!(u)-[]->(v)")
       .select("u.id", "v.id")
       .collect().toSet
-    assert(res === Set(
+    compareResultToExpected(res, Set(
+      Row(0L, 0L),
       Row(0L, 2L),
       Row(0L, 3L),
-      Row(1L, 0L),
+      Row(1L, 1L),
       Row(1L, 3L),
       Row(2L, 1L),
+      Row(2L, 2L),
       Row(3L, 0L),
       Row(3L, 1L),
-      Row(3L, 2L)
+      Row(3L, 2L),
+      Row(3L, 3L)
     ))
   }
 
@@ -346,7 +385,8 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     // edges whose destination leads nowhere
     val edges = g.find("()-[e]->(v); !(v)-[]->()")
       .select("e.src", "e.dst")
-    assert(edges.collect().toSet === Set(Row(2L, 3L)))
+    val res = edges.collect().toSet
+    compareResultToExpected(res, Set(Row(2L, 3L)))
   }
 
   test("a->b but not a->b") {
@@ -365,8 +405,11 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   test("find column order") {
     val fof = g.find("(u)-[e]->(v); (v)-[]->(w); !(u)-[]->(w); !(w)-[]->(u)")
+      .where("u.id != v.id AND v.id != w.id AND u.id != w.id")
     assert(fof.columns === Array("u", "e", "v", "w"))
-    assert(fof.select("u.id", "v.id", "w.id").collect().toSet === Set(Row(1L, 2L, 3L)))
+    compareResultToExpected(
+      fof.select("u.id", "v.id", "w.id").collect().toSet,
+      Set(Row(1L, 2L, 3L)))
 
     val fv = g.find("(u)")
     assert(fv.columns === Array("u"))
@@ -389,13 +432,13 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
   }
 
   test("Disallow named edges in negated terms") {
-    intercept[Exception] {
+    intercept[InvalidParseException] {
       g.find("!()-[ab]->()")
     }
-    intercept[Exception] {
+    intercept[InvalidParseException] {
       g.find("(u)-[]->(v); !(a)-[ab]->(b)")
     }
-    intercept[Exception] {
+    intercept[InvalidParseException] {
       g.find("(u)-[ab]->(v); !(a)-[ab]->(b)")
     }
   }
@@ -407,7 +450,8 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       .where("c.id = d.id AND e.id = a.id")
       .select("a.id", "b.id", "c.id")
 
-    assert(triangles.collect().toSet === Set(
+    val res = triangles.collect().toSet
+    compareResultToExpected(res, Set(
       Row(0L, 1L, 2L),
       Row(2L, 0L, 1L),
       Row(1L, 2L, 0L)
@@ -416,6 +460,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   test("stateful predicates via UDFs") {
     val chain4 = g.find("(a)-[ab]->(b); (b)-[bc]->(c); (c)-[cd]->(d)")
+      .where("a.id != b.id AND b.id != c.id AND c.id != a.id")
 
     // Using DataFrame operations, but not really operating in a stateful manner
     val chainWith2Friends = chain4.where(
@@ -438,7 +483,7 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       foldLeft(lit(0))((cnt, e) => sumFriends(cnt, col(e)("relationship")))
     val chainWith2Friends2 = chain4.where(condition >= 2)
 
-    assert(chainWith2Friends.collect().toSet === chainWith2Friends2.collect().toSet)
+    compareResultToExpected(chainWith2Friends.collect().toSet, chainWith2Friends2.collect().toSet)
   }
 
   /* ===================================== Join elimination =================================== */

--- a/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -151,6 +151,19 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     compareResultToExpected(res, expected)
   }
 
+  test("self-loop") {
+    val myE = sqlContext.createDataFrame(List(
+      (1L, 1L, "self"),
+      (3L, 3L, "self"))).toDF("src", "dst", "relationship")
+      .union(e)
+    val myG = GraphFrame(v, myE)
+
+    val selfLoops = myG.find("(a)-[]->(a)")
+    assert(selfLoops.columns === Array("a"))
+    val res = selfLoops.select("a.id").collect().toSet
+    compareResultToExpected(res, Set(Row(1L), Row(3L)))
+  }
+
   /* ======================== Multiple-edge queries without negated terms ===================== */
 
   test("triangle cycles") {

--- a/src/test/scala/org/graphframes/pattern/PatternSuite.scala
+++ b/src/test/scala/org/graphframes/pattern/PatternSuite.scala
@@ -24,8 +24,6 @@ class PatternSuite extends SparkFunSuite {
   test("good parses") {
     assert(Pattern.parse("(abc)") === Seq(NamedVertex("abc")))
 
-    assert(Pattern.parse("()") === Seq(AnonymousVertex))
-
     assert(Pattern.parse("(u)-[e]->(v)") ===
       Seq(NamedEdge("e", NamedVertex("u"), NamedVertex("v"))))
 
@@ -50,6 +48,16 @@ class PatternSuite extends SparkFunSuite {
   }
 
   test("bad parses") {
+    withClue("Failed to catch parse error with lone anonymous vertex") {
+      intercept[InvalidParseException] {
+        Pattern.parse("()")
+      }
+    }
+    withClue("Failed to catch parse error with lone anonymous vertex") {
+      intercept[InvalidParseException] {
+        Pattern.parse("(a)-[]->(b); ()")
+      }
+    }
     withClue("Failed to catch parse error") {
       intercept[InvalidParseException] {
         Pattern.parse("(")
@@ -102,6 +110,11 @@ class PatternSuite extends SparkFunSuite {
         Pattern.parse("(a)-[a]->(b)")
       }
     }
+    withClue("Failed to catch parse error with reused edge name") {
+      intercept[InvalidParseException] {
+        Pattern.parse("(a)-[e]->(b); ()-[e]->()")
+      }
+    }
   }
 
   test("empty pattern should be parsable") {
@@ -149,6 +162,6 @@ class PatternSuite extends SparkFunSuite {
     Seq("u", "v", "vw"))
 
   testFindNamedElementsInOrder(
-    "(u)-[uv]->(v); (v)-[uv]->(w); !(u)-[]->(w); (x)",
-    Seq("u", "uv", "v", "w", "x"))
+    "(u)-[uv]->(v); (v)-[vw]->(w); !(u)-[]->(w); (x)",
+    Seq("u", "uv", "v", "vw", "w", "x"))
 }


### PR DESCRIPTION
This PR fixes the issues discussed in https://github.com/graphframes/graphframes/issues/276

This is the follow-up to https://github.com/graphframes/graphframes/pull/279 which added helper methods to support this main PR.

Previously, we handled each term in the motif in the order given. For each new term, we augmented (a) the set of named elements and (b) the DataFrame representing all instances of the motifs.  This caused problems for named elements which only appeared in negated terms.

This implementation does the following:
* Separate non-negative terms from negative terms.
* Generate a DataFrame X of motif instances for the non-negative terms.
* Augment X with named vertices appearing only in negative terms. (This is 1 outer join with the vertex DataFrame per named vertex.)
* For each negative term, remove rows from X matching the negative term.

This PR also:
* fixes self-loop motifs a->a by adding an extra case into findIncremental()
* disallows certain motifs:
  * "()"
  * "()-[]->()" and "!()-[]->()"
  * motifs with reused edge names
* adds a bunch of unit tests