### PR TITLE
Remove 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,9 @@ env:
 matrix:
   include:
     - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.1.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - jdk: oraclejdk8
       env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
       env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.1.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
       env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You will need to set `SPARK_HOME` to your local Spark installation directory.
 
 ## Spark version compatibility
 
-This project is compatible with Spark 1.6+.  However, significant speed improvements have been
+This project is compatible with Spark 2.2+.  However, significant speed improvements have been
 made to DataFrames in more recent versions of Spark, so you may see speedups from using the latest
 Spark version.
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,6 @@
 val sparkVer = sys.props.getOrElse("spark.version", "2.3.1")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
-  case "2.1" => "2.11.8"
   case "2.2" => "2.11.8"
   case "2.3" => "2.11.8"
   case _ => throw new IllegalArgumentException(s"Unsupported Spark version: $sparkVer.")

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,7 +58,7 @@ Refer to the [Apache Spark documentation](http://spark.apache.org/docs/latest) f
 GraphFrames is compatible with Spark 1.6+.  However, later versions of Spark include major improvements
 to DataFrames, so GraphFrames may be more efficient when running on more recent Spark versions.
 
-GraphFrames is tested with Java 8, Python 2 and 3, and running against Spark 2.1+ (Scala 2.11).
+GraphFrames is tested with Java 8, Python 2 and 3, and running against Spark 2.2+ (Scala 2.11).
 
 # Applications, the Apache Spark shell, and clusters
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -697,7 +697,6 @@ val results2 = g.pageRank.resetProbability(0.15).maxIter(10).run()
 val results3 = g.pageRank.resetProbability(0.15).maxIter(10).sourceId("a").run()
 
 // Run PageRank personalized for vertex ["a", "b", "c", "d"] in parallel
-// Works only in Spark 2.1+
 val results3 = g.parallelPersonalizedPageRank.resetProbability(0.15).maxIter(10).sourceIds(Array("a", "b", "c", "d")).run()
 {% endhighlight %}
 </div>

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -333,8 +333,6 @@ class GraphFrameLibTest(GraphFrameTestCase):
         self._hasCols(pr, vcols=['id', 'pagerank'], ecols=['src', 'dst', 'weight'])
 
     def test_parallel_personalized_page_rank(self):
-        if not GraphFrameTestUtils.spark_at_least_of_version("2.1"):
-            self.skipTest("Parallel Personalized PageRank is only available in Apache Spark 2.1+")
         n = 100
         g = self._graph("star", n)
         resetProb = 0.15

--- a/python/graphframes/tests.py
+++ b/python/graphframes/tests.py
@@ -303,12 +303,8 @@ class GraphFrameLibTest(GraphFrameTestCase):
         comps_tests = []
         comps_tests += [g.connectedComponents()]
         comps_tests += [g.connectedComponents(broadcastThreshold=1)]
-
-        # [#194] Prior to Apache Spark version 2.0, no checkpoint or large checkpoint interval
-        #        causes the test to run for too long, resulting in Travis CI to abort the build
-        if GraphFrameTestUtils.spark_at_least_of_version("2.0"):
-            comps_tests += [g.connectedComponents(checkpointInterval=0)]
-            comps_tests += [g.connectedComponents(checkpointInterval=10)]
+        comps_tests += [g.connectedComponents(checkpointInterval=0)]
+        comps_tests += [g.connectedComponents(checkpointInterval=10)]
         comps_tests += [g.connectedComponents(algorithm="graphx")]
         for c in comps_tests:
             self.assertEqual(c.groupBy("component").count().count(), 2)


### PR DESCRIPTION
I can't see us publishing another version for 2.1 (mainly since it hits too many issues when users try motif finding), so this PR shortens the build by removing that support.