### PR TITLE
Update Travis to use Scala 2.11.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,20 @@ language: scala
 scala:
    - 2.11.8
 
+env:
+  global:
+    - SCALA_VERSION=2.11.8
+
 matrix:
   include:
     - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python2 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python3 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
     fi
 
 script:
-  - ./build/sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION "set test in assembly := {}" assembly
-  - ./build/sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION coverage test coverageReport
+  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
+  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$TRAVIS_SCALA_VERSION coverage test coverageReport
   - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
     fi
 
 script:
-  - ./build/sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
-  - ./build/sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test coverageReport
+  - ./build/sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION "set test in assembly := {}" assembly
+  - ./build/sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION coverage test coverageReport
   - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ language: scala
 scala:
    - 2.11.8
 
-env:
-  global:
-    - SCALA_VERSION=$TRAVIS_SCALA_VERSION
-
 matrix:
   include:
     - jdk: oraclejdk8
@@ -28,7 +24,6 @@ matrix:
 
 before_install:
  - ./bin/download_travis_dependencies.sh
- - unset SBT_OPTS
 
 install:
   - if [[ "${PYSPARK_PYTHON}" == "python2" ]]; then
@@ -40,8 +35,8 @@ install:
     fi
 
 script:
-  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
-  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$TRAVIS_SCALA_VERSION coverage test coverageReport
+  - sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
+  - sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test coverageReport
   - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ scala:
 
 env:
   global:
-    - SCALA_VERSION=$TRAVIS_SCALA_VERSION
+    - SCALA_VERSION=2.11.8
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ env:
 matrix:
   include:
     - jdk: oraclejdk8
-      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python2 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python3 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.2.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
     - jdk: oraclejdk8
-      env: SCALA_VERSION=2.11.8 PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+      env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ language: scala
 scala:
    - 2.11.8
 
+env:
+  global:
+    - SCALA_VERSION=$TRAVIS_SCALA_VERSION
+
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ install:
     fi
 
 script:
-  - sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
-  - sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test coverageReport
+  - sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION "set test in assembly := {}" assembly
+  - sbt ++$TRAVIS_SCALA_VERSION -Dspark.version=$SPARK_VERSION coverage test coverageReport
   - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
 
 before_install:
  - ./bin/download_travis_dependencies.sh
+ - unset SBT_OPTS
 
 install:
   - if [[ "${PYSPARK_PYTHON}" == "python2" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ language: scala
 scala:
    - 2.11.8
 
-env:
-  global:
-    - SCALA_VERSION=2.11.8
-
 matrix:
   include:
     - jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ cache:
     - $HOME/.sbt/launchers/
     - $HOME/.cache/spark-versions
 
-env:
-  global:
-    - SCALA_VERSION=2.11.8
+language: scala
+
+scala:
+   - 2.11.8
 
 matrix:
   include:
@@ -34,8 +35,8 @@ install:
     fi
 
 script:
-  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$SCALA_VERSION "set test in assembly := {}" assembly
-  - ./build/sbt -Dspark.version=$SPARK_VERSION -Dscala.version=$SCALA_VERSION coverage test coverageReport
+  - ./build/sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION "set test in assembly := {}" assembly
+  - ./build/sbt -Dspark.version=$SPARK_VERSION ++$TRAVIS_SCALA_VERSION coverage test coverageReport
   - SPARK_HOME=$HOME/.cache/spark-versions/$SPARK_BUILD ./python/run-tests.sh
 
 after_success:


### PR DESCRIPTION
The Travis version was not being set correctly, causing build failures for Spark 2.2 with Python 3 (weirdly).  This PR is meant to fix that.