### PR TITLE
Remove scalalogging-slf4j from dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ sparkComponents ++= Seq("graphx", "sql", "mllib")
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
 
-libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.21"
+libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.16"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % defaultScalaTestVer % "test"
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,14 +43,9 @@ sparkComponents ++= Seq("graphx", "sql", "mllib")
 // add any Spark Package dependencies using spDependencies.
 // e.g. spDependencies += "databricks/spark-avro:0.1"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % defaultScalaTestVer % "test"
+libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.21"
 
-// These versions are ancient, but they cross-compile around scala 2.10 and 2.11.
-// Update them when dropping support for scala 2.10
-libraryDependencies ++= Seq(
-  "com.typesafe.scala-logging" %% "scala-logging-api" % "2.1.2",
-  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
-)
+libraryDependencies += "org.scalatest" %% "scalatest" % defaultScalaTestVer % "test"
 
 parallelExecution := false
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -616,7 +616,7 @@ object GraphFrame extends Serializable with Logging {
       // No skew.  Do regular join.
       a.join(b, joinCol)
     } else {
-      logger.debug(s"$logPrefix Skewed join with ${hubs.size} high-degree keys.")
+      logDebug(s"$logPrefix Skewed join with ${hubs.size} high-degree keys.")
       val isHub = udf { id: T =>
         hubs.contains(id)
       }

--- a/src/main/scala/org/graphframes/Logging.scala
+++ b/src/main/scala/org/graphframes/Logging.scala
@@ -17,11 +17,26 @@
 
 package org.graphframes
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.slf4j.{Logger, LoggerFactory}
 
 // This needs to be accessible to org.apache.spark.graphx.lib.backport
-private[org] trait Logging extends LazyLogging {
-  protected def logDebug(s: String) = logger.debug(s)
-  protected def logInfo(s: String) = logger.info(s)
-  protected def logTrace(s: String) = logger.trace(s)
+private[org] trait Logging {
+
+  @transient private lazy val logger: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  protected def logDebug(s: => String): Unit = {
+    if (logger.isDebugEnabled) logger.debug(s)
+  }
+
+  protected def logWarn(s: => String): Unit = {
+    if (logger.isWarnEnabled) logger.warn(s)
+  }
+
+  protected def logInfo(s: => String): Unit = {
+    if (logger.isInfoEnabled) logger.info(s)
+  }
+
+  protected def logTrace(s: => String): Unit = {
+    if (logger.isTraceEnabled) logger.trace(s)
+  }
 }


### PR DESCRIPTION
In this PR I've removed scala-logging-slf4j in favor of bare slf4j-api. 

GraphFrames depends on scala-logging v.2.1.2 which is incompatible with later scala-logging 3.x. Thus if other dependencies introduce scala-logging 3.x you get `java.lang.IncompatibleClassChangeError`. So you have to use shading to overcome this issue.

Simply upgrading scala-logging to 3.x will break Scala 2.10 cross-compilation for GraphFrames because 3.x is not available for Scala 2.10. So maybe it's better to remove scala-logging dependency in favor of bare slf4j-api, just like in Spark (see [this commit](https://github.com/apache/spark/commit/4c477117bb1ffef463776c86f925d35036f96b7a) in Spark)

