### PR TITLE
[ML-5491] Add release script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 // Your sbt build file. Guides on how to write one can be found at
 // http://www.scala-sbt.org/0.13/docs/index.html
 
+import ReleaseTransformations._
+
 val sparkVer = sys.props.getOrElse("spark.version", "2.3.1")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
@@ -24,10 +26,9 @@ spName := "graphframes/graphframes"
 
 organization := "org.graphframes"
 
-isSnapshot := true
+version := (version in ThisBuild).value + s"-spark$sparkBranch"
 
-// Don't forget to set the version
-version := s"0.7.0-spark$sparkBranch${if (isSnapshot.value) "-SNAPSHOT" else ""}"
+isSnapshot := version.value.contains("SNAPSHOT")
 
 // All Spark Packages need a license
 licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0"))
@@ -68,3 +69,13 @@ concurrentRestrictions in Global := Seq(
 autoAPIMappings := true
 
 coverageHighlighting := false
+
+// We only use sbt-release to update version numbers.
+releaseProcess := Seq[ReleaseStep](
+  inquireVersions,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion
+)

--- a/dev/release.py
+++ b/dev/release.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+import click
+from datetime import datetime
+from subprocess import check_call, check_output
+import sys
+
+DATABRICKS_REMOTE = "git@github.com:graphframes/graphframes.git"
+PUBLISH_MODES = {
+    "local": "publishLocal",
+    "m2": "publishM2",
+    "spark-package-publish": "spPublish",
+}
+PUBLISH_DOCS_DEFAULT = True
+
+WORKING_BRANCH = "WORKING_BRANCH_RELEASE_%s_@%s"
+# lower case "z" puts the branch at the end of the github UI.
+WORKING_DOCS_BRANCH = "zWORKING_BRANCH_DOCS_%s_@%s"
+RELEASE_TAG = "v%s"
+
+
+def prominentPrint(x):
+    click.echo(click.style(x, underline=True))
+
+
+def verify(prompt, interactive):
+    if not interactive:
+        return True
+    return click.confirm(prompt, show_default=True)
+
+
+@click.command()
+@click.argument("release-version", type=str)
+@click.argument("next-version", type=str)
+@click.option("--publish-to", default="local", show_default=True,
+              help="Where to publish artifact, one of: %s" % list(PUBLISH_MODES.keys()))
+@click.option("--no-prompt", is_flag=True, help="Automated mode with no user prompts.")
+@click.option("--git-remote", default=DATABRICKS_REMOTE,
+              help="Push current branch and docs to this git remote.")
+@click.option("--publish-docs", type=bool, default=PUBLISH_DOCS_DEFAULT, show_default=True,
+              help="Publish docs to github-pages.")
+def main(release_version, next_version, publish_to, no_prompt, git_remote, publish_docs):
+    interactive = not no_prompt
+
+    time = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+    if publish_to not in PUBLISH_MODES:
+        modes = list(PUBLISH_MODES.keys())
+        prominentPrint("Unknown publish target, --publish-to should be one of: %s." % modes)
+        sys.exit(1)
+
+    if not next_version.endswith("SNAPSHOT"):
+        next_version += "-SNAPSHOT"
+
+    if not verify("Publishing version: %s\n"
+                    "Next version will be: %s\n"
+                    "Continue?" % (release_version, next_version), interactive):
+        sys.exit(1)
+
+    current_branch = check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+    if current_branch == "HEAD":
+        prominentPrint("Cannot build from detached head state. Please make a branch.")
+        sys.exit(1)
+    if current_branch != b"master":
+        if not verify("You're not on the master branch do you want to continue?",
+                      interactive):
+            sys.exit(1)
+
+    uncommitted_changes = check_output(["git", "diff", "--stat"])
+    if uncommitted_changes != b"":
+        prominentPrint("There seem to be uncommitted changes on your current branch. Please commit or "
+              "stash them and try again.")
+        prominentPrint(uncommitted_changes)
+        sys.exit(1)
+
+    working_branch = WORKING_BRANCH % (release_version, time)
+    gh_pages_branch = WORKING_DOCS_BRANCH % (release_version, time)
+
+    release_tag = RELEASE_TAG % release_version
+    target_tags = [release_tag]
+
+    existing_tags = check_output(["git", "tag"]).decode().split()
+    conflict_tags = list(filter(lambda a: a in existing_tags, target_tags))
+    if conflict_tags:
+        msg = ("The following tags already exist:\n"
+               "    %s\n"
+               "Please delete them and try.")
+        msg = msg % "\n    ".join(conflict_tags)
+        prominentPrint(msg)
+        sys.exit(1)
+
+    prominentPrint("Creating working branch for this release.")
+    check_call(["git", "checkout", "-b", working_branch])
+
+    prominentPrint("Creating release tag and updating snapshot version.")
+    update_version = "release release-version %s next-version %s" % (release_version, next_version)
+    check_call(["./build/sbt", update_version])
+
+    prominentPrint("Building and testing with sbt.")
+    check_call(["git", "checkout", release_tag])
+
+    publish_target = PUBLISH_MODES[publish_to]
+    check_call(["./build/sbt", "clean", publish_target])
+
+    prominentPrint("Updating local branch: %s" % current_branch)
+    check_call(["git", "checkout", current_branch])
+    check_call(["git", "merge", "--ff", working_branch])
+    check_call(["git", "branch", "-d", working_branch])
+
+    prominentPrint("Local branch updated")
+    if verify("Would you like to push local branch & version tag to remote: %s?" % git_remote,
+              interactive):
+        check_call(["git", "push", git_remote, current_branch])
+        check_call(["git", "push", git_remote, release_tag])
+
+    prominentPrint("Building release docs")
+
+    if not (publish_docs and verify("Would you like to build release docs?", interactive)):
+        # All done, exit happy
+        sys.exit(0)
+
+    check_call(["git", "checkout", "-b", gh_pages_branch, release_tag])
+    check_call(["./dev/build-docs.sh"])
+
+    commit_message = "Build docs for release %s." % release_version
+    check_call(["git", "add", "-f", "docs/_site"])
+    check_call(["git", "commit", "-m", commit_message])
+    msg = "Would you like to push docs branch to %s and update gh-pages branch?"
+    msg %= git_remote
+    if verify(msg, interactive):
+        check_call(["git", "push", git_remote, gh_pages_branch])
+        check_call(["git", "push", "-f", git_remote, gh_pages_branch+":gh-pages"])
+
+    check_call(["git", "checkout", current_branch])
+    check_call(["git", "branch", "-D", gh_pages_branch])
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/release.py
+++ b/dev/release.py
@@ -56,7 +56,7 @@ def main(release_version, next_version, publish_to, no_prompt, git_remote, publi
         sys.exit(1)
 
     current_branch = check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-    if current_branch == "HEAD":
+    if current_branch == b"HEAD":
         prominentPrint("Cannot build from detached head state. Please make a branch.")
         sys.exit(1)
     if current_branch != b"master":

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 // scalacOptions in (Compile,doc) := Seq("-groups", "-implicits")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.7.0-SNAPSHOT"


### PR DESCRIPTION
This PR adds a script to graphframes to make publishing releases and docs easier and more reproducible. We follow the release release script and doc build pattern used in https://github.com/databricks/spark-deep-learning.