### PR TITLE
[ML-5967] Add spark-packages-credential file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,3 +81,5 @@ releaseProcess := Seq[ReleaseStep](
   setNextVersion,
   commitNextVersion
 )
+
+credentials += Credentials(Path.userHome / ".spark-packages-credential")


### PR DESCRIPTION
This credential file will be used by realease.py (via ./build/sbt spPublish), it's only needed by developers who push releases to spark-packages.