### PR TITLE
[ML-5994] Update Pregel API docs (Scala)

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -23,7 +23,7 @@ from pyspark import SparkContext
 from pyspark.sql import Column, DataFrame, SQLContext
 from pyspark.storagelevel import StorageLevel
 
-from graphframes.pregel import Pregel
+from graphframes.lib import Pregel
 
 
 def _from_java_gf(jgf, sqlContext):

--- a/python/graphframes/lib/__init__.py
+++ b/python/graphframes/lib/__init__.py
@@ -1,4 +1,5 @@
 
 from .aggregate_messages import AggregateMessages
+from .pregel import Pregel
 
-__all__ = ['AggregateMessages']
+__all__ = ['AggregateMessages', 'Pregel']

--- a/python/graphframes/lib/pregel.py
+++ b/python/graphframes/lib/pregel.py
@@ -45,7 +45,7 @@ class Pregel(JavaWrapper):
 
     :param gf :class:`GraphFrame` holding a graph with vertices and edges stored as DataFrames.
 
-    >>> from .graphframe import GraphFrame, Pregel
+    >>> from graphframe import GraphFrame
     >>> from pyspark.sql.functions import coalesce, col, lit, sum, when
     >>> edges = spark.createDataFrame([[0, 1],
     ...                                [1, 2],
@@ -74,7 +74,7 @@ class Pregel(JavaWrapper):
     def __init__(self, gf):
         super(Pregel, self).__init__()
         self.graph = gf
-        self._java_obj = self._new_java_obj("org.graphframes.Pregel", gf._jvm_graph)
+        self._java_obj = self._new_java_obj("org.graphframes.lib.Pregel", gf._jvm_graph)
 
     def setMaxIter(self, value):
         """

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -58,13 +58,6 @@ class GraphFrame private(
   }
 
   /**
-   *  Get the `Pregel` object for running pregel.
-   *
-   *  See [[org.graphframes.Pregel]] for more details.
-   */
-  def pregel = new Pregel(this)
-
-  /**
    * Persist the dataframe representation of vertices and edges of the graph with the default
    * storage level.
    */
@@ -452,6 +445,14 @@ class GraphFrame private(
     */
   def parallelPersonalizedPageRank: ParallelPersonalizedPageRank =
     new ParallelPersonalizedPageRank(this)
+
+  /**
+   * Pregel algorithm.
+   *
+   * @see [[org.graphframes.lib.Pregel]]
+   * @group stdlib
+   */
+  def pregel = new Pregel(this)
 
   /**
    * Shortest paths algorithm.

--- a/src/main/scala/org/graphframes/lib/Pregel.scala
+++ b/src/main/scala/org/graphframes/lib/Pregel.scala
@@ -35,10 +35,9 @@ import org.apache.spark.sql.functions.{array, col, explode, struct}
  * When a run starts, it expands the vertices DataFrame using column expressions defined by [[withVertexColumn]].
  * Those additional vertex properties can be changed during Pregel iterations.
  * In each Pregel iteration, there are three phases:
- *   - Given each triplet, generate messages and targets to send,
+ *   - Given each edge triplet, generate messages and specify target vertices to send,
  *     described by [[sendMsgToDst]] and [[sendMsgToSrc]].
- *   - Aggregate messages by destination vertex IDs, described by [[aggMsgs]].
- *
+ *   - Aggregate messages by target vertex IDs, described by [[aggMsgs]].
  *   - Update additional vertex properties based on aggregated messages and states from previous iteration,
  *     described by [[withVertexColumn]].
  *
@@ -250,7 +249,7 @@ class Pregel(val graph: GraphFrame) {
 object Pregel extends Serializable {
 
   /**
-   * A constant column name for generated and messaged messages.
+   * A constant column name for generated and aggregated messages.
    *
    * The vertices DataFrame must not contain this column.
    */

--- a/src/main/scala/org/graphframes/lib/Pregel.scala
+++ b/src/main/scala/org/graphframes/lib/Pregel.scala
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.graphframes
+package org.graphframes.lib
 
+import org.graphframes.GraphFrame
 import org.graphframes.GraphFrame._
 import org.apache.spark.sql.{Column, DataFrame}
 import org.apache.spark.sql.functions.{array, col, explode, struct}

--- a/src/test/scala/org/graphframes/lib/PregelSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PregelSuite.scala
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
-package org.graphframes
+package org.graphframes.lib
 
 import org.scalactic.Tolerance._
 
 import org.apache.spark.sql.functions._
+
+import org.graphframes._
 
 class PregelSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 

--- a/src/test/scala/org/graphframes/lib/PregelSuite.scala
+++ b/src/test/scala/org/graphframes/lib/PregelSuite.scala
@@ -48,7 +48,7 @@ class PregelSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       .withVertexColumn("rank", lit(1.0 / numVertices),
         coalesce(Pregel.msg, lit(0.0)) * (1.0 - alpha) + alpha / numVertices)
       .sendMsgToDst(Pregel.src("rank") / Pregel.src("outDegree"))
-      .aggMsgs(sum(Pregel.MSG_COL_NAME))
+      .aggMsgs(sum(Pregel.msg))
       .run()
 
     val result = ranks.sort(col("id"))


### PR DESCRIPTION
* moved `Pregel` to `graphframes.lib`.
* updated all API doc in Scala
* added example code to API doc
* No real code changes.

After this one gets reviewed and merged, I will send a follow-up PR for Python API doc changes.