### PR TITLE
[ML-5995] Update pregel Python API doc

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -192,7 +192,7 @@ class GraphFrame(object):
         """
         Get the `Pregel` object for running pregel.
 
-        See :class:`graphframes.Pregel` for more details.
+        See :class:`graphframes.lib.Pregel` for more details.
         """
         return Pregel(self)
 

--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -190,7 +190,7 @@ class GraphFrame(object):
     @property
     def pregel(self):
         """
-        Get the `Pregel` object for running pregel.
+        Get the :class:`graphframes.lib.Pregel` object for running pregel.
 
         See :class:`graphframes.lib.Pregel` for more details.
         """

--- a/python/graphframes/lib/pregel.py
+++ b/python/graphframes/lib/pregel.py
@@ -25,7 +25,7 @@ from pyspark.ml.wrapper import JavaWrapper, _jvm
 
 
 class Pregel(JavaWrapper):
-    """
+    r"""
     Implements a Pregel-like bulk-synchronous message-passing API based on DataFrame operations.
 
     See `Malewicz et al., Pregel: a system for large-scale graph processing <https://doi.org/10.1145/1807167.1807184>`_
@@ -71,7 +71,7 @@ class Pregel(JavaWrapper):
     >>> alpha = 0.15
     >>> ranks = graph.pregel \
     ...     .setMaxIter(5) \
-    ...     .withVertexColumn("rank", lit(1.0 / numVertices),
+    ...     .withVertexColumn("rank", lit(1.0 / numVertices), \
     ...         coalesce(Pregel.msg(), lit(0.0)) * lit(1.0 - alpha) + lit(alpha / numVertices)) \
     ...     .sendMsgToDst(Pregel.src("rank") / Pregel.src("outDegree")) \
     ...     .aggMsgs(sum(Pregel.msg())) \

--- a/python/graphframes/lib/pregel.py
+++ b/python/graphframes/lib/pregel.py
@@ -28,12 +28,12 @@ class Pregel(JavaWrapper):
     """
     Implements a Pregel-like bulk-synchronous message-passing API based on DataFrame operations.
 
-    See <a href="https://doi.org/10.1145/1807167.1807184">Malewicz et al., Pregel: a system for large-scale graph
-    processing</a> for a detailed description of the Pregel algorithm.
+    See `Malewicz et al., Pregel: a system for large-scale graph processing <https://doi.org/10.1145/1807167.1807184>`_
+    for a detailed description of the Pregel algorithm.
 
-    You can construct a Pregel instance using either this constructor or `graphframes.GraphFrame.pregel`,
+    You can construct a Pregel instance using either this constructor or `graphframes.lib.pregel`,
     then use builder pattern to describe the operations, and then call `run` to start a run.
-    It returns a DataFrame of vertices from the last iteration.
+    It returns a `DataFrame` of vertices from the last iteration.
 
     When a run starts, it expands the vertices DataFrame using column expressions defined by `withVertexColumn`.
     Those additional vertex properties can be changed during Pregel iterations.
@@ -49,11 +49,9 @@ class Pregel(JavaWrapper):
     You can control the number of iterations by `setMaxIter` and check API docs for advanced controls.
 
     See `graphframes.GraphFrame.pregel`.
-    See <a href="https://doi.org/10.1145/1807167.1807184">
-          Malewicz et al., Pregel: a system for large-scale graph processing.
-        </a>
+    See `Malewicz et al., Pregel: a system for large-scale graph processing <https://doi.org/10.1145/1807167.1807184>`_.
 
-    :param gf :class:`graphframes.GraphFrame` holding a graph with vertices and edges stored as DataFrames.
+    :param graph: a `graphframes.GraphFrame` holding a graph with vertices and edges stored as DataFrames.
 
     >>> from graphframe import GraphFrame
     >>> from pyspark.sql.functions import coalesce, col, lit, sum, when
@@ -71,20 +69,19 @@ class Pregel(JavaWrapper):
     >>> vertices.cache()
     >>> graph = GraphFrame(vertices, edges)
     >>> alpha = 0.15
-    >>> pageRankResultDF = graph.pregel \
-    ...   .setMaxIter(5) \
-    ...   .withVertexColumn("rank", lit(1.0 / numVertices),
-    ...                     coalesce(Pregel.msg(),
-    ...                              lit(0.0)) * lit(1.0 - alpha) + lit(alpha / numVertices)) \
-    ...   .sendMsgToDst(Pregel.src("rank") / Pregel.src("outDegree")) \
-    ...   .aggMsgs(sum(Pregel.msg())) \
-    ...   .run()
+    >>> ranks = graph.pregel \
+    ...     .setMaxIter(5) \
+    ...     .withVertexColumn("rank", lit(1.0 / numVertices),
+    ...         coalesce(Pregel.msg(), lit(0.0)) * lit(1.0 - alpha) + lit(alpha / numVertices)) \
+    ...     .sendMsgToDst(Pregel.src("rank") / Pregel.src("outDegree")) \
+    ...     .aggMsgs(sum(Pregel.msg())) \
+    ...     .run()
     """
 
-    def __init__(self, gf):
+    def __init__(self, graph):
         super(Pregel, self).__init__()
-        self.graph = gf
-        self._java_obj = self._new_java_obj("org.graphframes.lib.Pregel", gf._jvm_graph)
+        self.graph = graph
+        self._java_obj = self._new_java_obj("org.graphframes.lib.Pregel", graph._jvm_graph)
 
     def setMaxIter(self, value):
         """

--- a/python/graphframes/lib/pregel.py
+++ b/python/graphframes/lib/pregel.py
@@ -31,27 +31,28 @@ class Pregel(JavaWrapper):
     See `Malewicz et al., Pregel: a system for large-scale graph processing <https://doi.org/10.1145/1807167.1807184>`_
     for a detailed description of the Pregel algorithm.
 
-    You can construct a Pregel instance using either this constructor or `graphframes.lib.pregel`,
-    then use builder pattern to describe the operations, and then call `run` to start a run.
-    It returns a `DataFrame` of vertices from the last iteration.
+    You can construct a Pregel instance using either this constructor or :attr:`graphframes.GraphFrame.pregel`,
+    then use builder pattern to describe the operations, and then call :func:`run` to start a run.
+    It returns a DataFrame of vertices from the last iteration.
 
-    When a run starts, it expands the vertices DataFrame using column expressions defined by `withVertexColumn`.
+    When a run starts, it expands the vertices DataFrame using column expressions defined by :func:`withVertexColumn`.
     Those additional vertex properties can be changed during Pregel iterations.
     In each Pregel iteration, there are three phases:
       - Given each edge triplet, generate messages and specify target vertices to send,
-        described by `sendMsgToDst` and `sendMsgToSrc`.
-      - Aggregate messages by target vertex IDs, described by `aggMsgs`.
+        described by :func:`sendMsgToDst` and :func:`sendMsgToSrc`.
+      - Aggregate messages by target vertex IDs, described by :func:`aggMsgs`.
       - Update additional vertex properties based on aggregated messages and states from previous iteration,
-        described by `withVertexColumn`.
+        described by :func:`withVertexColumn`.
 
     Please find what columns you can reference at each phase in the method API docs.
 
-    You can control the number of iterations by `setMaxIter` and check API docs for advanced controls.
+    You can control the number of iterations by :func:`setMaxIter` and check API docs for advanced controls.
 
-    See `graphframes.GraphFrame.pregel`.
+    See :attr:`graphframes.GraphFrame.pregel`.
+
     See `Malewicz et al., Pregel: a system for large-scale graph processing <https://doi.org/10.1145/1807167.1807184>`_.
 
-    :param graph: a `graphframes.GraphFrame` holding a graph with vertices and edges stored as DataFrames.
+    :param graph: a :class:`graphframes.GraphFrame` object holding a graph with vertices and edges stored as DataFrames.
 
     >>> from graphframe import GraphFrame
     >>> from pyspark.sql.functions import coalesce, col, lit, sum, when
@@ -114,7 +115,7 @@ class Pregel(JavaWrapper):
                             You can reference all original vertex columns in this expression.
         :param updateAfterAggMsgsExpr: the expression to update the additional vertex column after messages aggregation.
                                        You can reference all original vertex columns, additional vertex columns, and the
-                                       aggregated message column using `Pregel.msg()`.
+                                       aggregated message column using :func:`msg`.
                                        If the vertex received no messages, the message column would be null.
         """
         self._java_obj.withVertexColumn(colName, initialExpr._jc, updateAfterAggMsgsExpr._jc)
@@ -126,12 +127,12 @@ class Pregel(JavaWrapper):
 
         You can call it multiple times to send more than one messages.
 
-        See method `sendMsgToDst`.
+        See method :func:`sendMsgToDst`.
 
         :param msgExpr: the expression of the message to send to the source vertex given a (src, edge, dst) triplet.
                         Source/destination vertex properties and edge properties are nested under columns `src`, `dst`,
                         and `edge`, respectively.
-                        You can reference them using `Pregel.src`, `Pregel.dst`, and `Pregel.edge`.
+                        You can reference them using :func:`src`, :func:`dst`, and :func:`edge`.
                         Null messages are not included in message aggregation.
         """
         self._java_obj.sendMsgToSrc(msgExpr._jc)
@@ -143,12 +144,12 @@ class Pregel(JavaWrapper):
 
         You can call it multiple times to send more than one messages.
 
-        See method `sendMsgToSrc`.
+        See method :func:`sendMsgToSrc`.
 
         :param msgExpr: the message expression to send to the destination vertex given a (`src`, `edge`, `dst`) triplet.
                         Source/destination vertex properties and edge properties are nested under columns `src`, `dst`,
                         and `edge`, respectively.
-                        You can reference them using `Pregel.src`, `Pregel.dst`, and `Pregel.edge`.
+                        You can reference them using :func:`src`, :func:`dst`, and :func:`edge`.
                         Null messages are not included in message aggregation.
         """
         self._java_obj.sendMsgToDst(msgExpr._jc)
@@ -158,8 +159,8 @@ class Pregel(JavaWrapper):
         """
         Defines how messages are aggregated after grouped by target vertex IDs.
 
-        :param aggExpr: the message aggregation expression, such as `sum(Pregel.msg)`.
-                        You can reference the message column by `Pregel.msg()` and the vertex ID by `col("id")`,
+        :param aggExpr: the message aggregation expression, such as `sum(Pregel.msg())`.
+                        You can reference the message column by :func:`msg` and the vertex ID by `col("id")`,
                         while the latter is usually not used.
         """
         self._java_obj.aggMsgs(aggExpr._jc)
@@ -178,7 +179,7 @@ class Pregel(JavaWrapper):
         """
         References the message column in aggregating messages and updating additional vertex columns.
 
-        See `Pregel.aggMsgs` and `Pregel.withVertexColumn`
+        See :func:`aggMsgs` and :func:`withVertexColumn`
         """
         return col("_pregel_msg_")
 
@@ -187,7 +188,7 @@ class Pregel(JavaWrapper):
         """
         References a source vertex column in generating messages to send.
 
-        See `Pregel.sendMsgToSrc` and `Pregel.sendMsgToDst`
+        See :func:`sendMsgToSrc` and :func:`sendMsgToDst`
 
         :param colName: the vertex column name.
         """
@@ -198,7 +199,7 @@ class Pregel(JavaWrapper):
         """
         References a destination vertex column in generating messages to send.
 
-        See `Pregel.sendMsgToSrc` and `Pregel.sendMsgToDst`
+        See :func:`sendMsgToSrc` and :func:`sendMsgToDst`
 
         :param colName: the vertex column name.
         """
@@ -209,7 +210,7 @@ class Pregel(JavaWrapper):
         """
         References an edge column in generating messages to send.
 
-        See `Pregel.sendMsgToSrc` and `Pregel.sendMsgToDst`
+        See :func:`sendMsgToSrc` and :func:`sendMsgToDst`
 
         :param colName: the edge column name.
         """


### PR DESCRIPTION
Update pregel Python API doc.

Mostly, I copy the refined scala doc to python side.

Screen shot:
<img width="984" alt="01" src="https://user-images.githubusercontent.com/19235986/50754500-eb131e00-1290-11e9-872b-f052cdec1fba.png">
<img width="966" alt="02" src="https://user-images.githubusercontent.com/19235986/50754505-ecdce180-1290-11e9-90a8-1a9c9928cdb8.png">
<img width="944" alt="03" src="https://user-images.githubusercontent.com/19235986/50754509-f0706880-1290-11e9-809d-3dd7dc3f1065.png">
<img width="933" alt="04" src="https://user-images.githubusercontent.com/19235986/50754514-f36b5900-1290-11e9-9619-c29d529d2eb6.png">
