### PR TITLE
[ML-5815] [FOLLOW-UP] Change pregel default checkpointInterval to be 1

### DIFF
--- a/src/main/scala/org/graphframes/lib/Pregel.scala
+++ b/src/main/scala/org/graphframes/lib/Pregel.scala
@@ -72,7 +72,7 @@ class Pregel(val graph: GraphFrame) {
   private val withVertexColumnList = collection.mutable.ListBuffer.empty[(String, Column, Column)]
 
   private var maxIter: Int = 10
-  private var checkpointInterval = 2
+  private var checkpointInterval = 1
 
   private var sendMsgs = collection.mutable.ListBuffer.empty[(Column, Column)]
   private var aggMsgsCol: Column = null
@@ -86,7 +86,7 @@ class Pregel(val graph: GraphFrame) {
   }
 
   /**
-   * Sets the number of iterations between two checkpoints (default: 2).
+   * Sets the number of iterations between two checkpoints (default: 1).
    *
    * This is an advanced control to balance query plan optimization and checkpoint data I/O cost.
    * In most cases, you should keep the default value.


### PR DESCRIPTION
Change pregel default checkpointInterval to be 1.

In my test, this will reduce SQL planner time in several cases.
And localCheckpoint is very fast so more frequent checkpoint won't increase execution time too much.