### PR TITLE
[ML-5967] Publish with spDist

### DIFF
--- a/dev/release.py
+++ b/dev/release.py
@@ -8,7 +8,7 @@ DATABRICKS_REMOTE = "git@github.com:graphframes/graphframes.git"
 PUBLISH_MODES = {
     "local": "publishLocal",
     "m2": "publishM2",
-    "spark-package-publish": "spPublish",
+    "spark-package-publish": "spDist",
 }
 PUBLISH_DOCS_DEFAULT = True
 


### PR DESCRIPTION
Use spDist with manual upload to publish instead of spPublish because the upload step of spDist if flaky.