### PR TITLE
Changes the output label of CC to min of original ID

### DIFF
--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -235,7 +235,7 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
       expected: Set[Set[T]]): Unit = {
     import actual.sqlContext.implicits._
     // note: not using agg + collect_list because collect_list is not available in 1.6.2 w/o hive
-    val actualComponents = actual.select("component", "id").as[(Long, T)].rdd
+    val actualComponents = actual.select("component", "id").as[(T, T)].rdd
       .groupByKey()
       .values
       .map(_.toSeq)


### PR DESCRIPTION
This PR changes the label to minimum of the vertex ID belonging to a component.
The assigned label of output of Connected Component is currently a random number which is not consistent. If some delta edges are added to the graph, the output label of unaffected components also changes. 

Output of friends graph example:
<img width="331" alt="friends graph output" src="https://user-images.githubusercontent.com/13175324/52523320-1d5fd300-2cb6-11e9-89e8-2262cba708a0.png">
