### PR TITLE
Bump Spark and sbt version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
 
 matrix:
   include:
-    - env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.4.0 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.4.0 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.3.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python2 SPARK_VERSION=2.4.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.3.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SPARK_VERSION=2.4.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
 
 before_install:
  - ./bin/download_travis_dependencies.sh

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ scalacOptions in (Test, doc) ++= Seq("-groups", "-implicits")
 fork in Test := true
 
 // This and the next line fix a problem with forked run: https://github.com/scalatest/scalatest/issues/770
-javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-XX:MaxPermSize=384m")
+javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-XX:MaxMetaspaceSize=384m")
 
 concurrentRestrictions in Global := Seq(
   Tags.limitAll(1))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-// This file should only contain the version of sbt to use.
-sbt.version=0.13.17
+# This file should only contain the version of sbt to use.
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ addSbtPlugin("org.spark-packages" %% "sbt-spark-package" % "0.2.6")
 
 // scalacOptions in (Compile,doc) := Seq("-groups", "-implicits")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")


### PR DESCRIPTION
We have to update Spark patch version since **there are no 2.3.2 and 2.4.0 at mirror site**. In the meantime, I update sbt and sbt-plugins' patch version. 