### PR TITLE
Remove unnecessary count and log statements

### DIFF
--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -308,8 +308,6 @@ object ConnectedComponents extends Logging {
     val g = prepare(graph)
     val vv = g.vertices
     var ee = g.edges.persist(intermediateStorageLevel) // src < dst
-    val numEdges = ee.count()
-    logInfo(s"$logPrefix Found $numEdges edges after preparation.")
 
     var converged = false
     var iteration = 1


### PR DESCRIPTION
Removes a count and log statement that have negative performance impacts and result only in some logging.