### PR TITLE
removed expensive computation from connected components

### DIFF
--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -308,8 +308,6 @@ object ConnectedComponents extends Logging {
     val g = prepare(graph)
     val vv = g.vertices
     var ee = g.edges.persist(intermediateStorageLevel) // src < dst
-    val numEdges = ee.count()
-    logInfo(s"$logPrefix Found $numEdges edges after preparation.")
 
     var converged = false
     var iteration = 1


### PR DESCRIPTION
These lines in Connected Components are only used for logging and the computation of the count can be rather expensive:

    val numEdges = ee.count()
    logInfo(s"$logPrefix Found $numEdges edges after preparation.")