### PR TITLE
Remove the use of deprecated methods and warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ libraryDependencies += "com.github.zafarkhaja" % "java-semver" % "0.9.0" % "test
 
 parallelExecution := false
 
-scalacOptions ++= Seq("-deprecation", "-Xfatal-warnings", "-feature")
+scalacOptions ++= Seq("-deprecation", "-feature")
 
 scalacOptions in (Compile, doc) ++= Seq(
   "-groups",

--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,8 @@ libraryDependencies += "com.github.zafarkhaja" % "java-semver" % "0.9.0" % "test
 
 parallelExecution := false
 
+scalacOptions ++= Seq("-deprecation", "-Xfatal-warnings", "-feature")
+
 scalacOptions in (Compile, doc) ++= Seq(
   "-groups",
   "-implicits",

--- a/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -72,18 +72,18 @@ private object ShortestPaths {
     val g = GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(DISTANCE_ID))
     val distanceCol: Column = if (graph.hasIntegralIdType) {
       // It seems there are no easy way to convert a sequence of pairs into a map
-      val mapToLandmark = udf({ distances: Seq[Row] =>
+      val mapToLandmark = udf { distances: Seq[Row] =>
         distances.map { case Row(k: Long, v: Int) =>
           k -> v
         }.toMap
-      }, MapType(idType, IntegerType, false))
+      }
       mapToLandmark(g.vertices(DISTANCE_ID))
     } else {
-      val mapToLandmark = udf({ distances: Seq[Row] =>
+      val mapToLandmark = udf { distances: Seq[Row] =>
         distances.map { case Row(k: Long, v: Int) =>
           longIdToLandmark(k) -> v
         }.toMap
-      }, MapType(idType, IntegerType, false))
+      }
       mapToLandmark(col(DISTANCE_ID))
     }
     val cols = graph.vertices.columns.map(col) :+ distanceCol.as(DISTANCE_ID)

--- a/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -40,7 +40,7 @@ private[graphframes] object PatternParser extends RegexParsers {
   private val edge: Parser[Edge] = namedEdge | anonymousEdge
   private val negatedEdge: Parser[Pattern] =
     "!" ~ edge ^^ {
-      case "!" ~ e => Negation(e)
+      case _ ~ e => Negation(e)
     }
   private val pattern: Parser[Pattern] = edge | vertex | negatedEdge
   val patterns: Parser[List[Pattern]] = repsep(pattern, ";")

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -8,3 +8,5 @@ log4j.logger.org.eclipse.jetty.util.component.AbstractLifeCycle=ERROR
 log4j.logger.org.apache.spark=WARN
 log4j.logger.org.apache.spark.repl.SparkIMain$exprTyper=INFO
 log4j.logger.org.apache.spark.repl.SparkILoop$SparkILoopInterpreter=INFO
+# Hide many "WARN CacheManager: Asked to cache already cached data" warnings.
+log4j.logger.org.apache.spark.sql.execution.CacheManager=ERROR


### PR DESCRIPTION
* Untyped Scala UDF is disabled at runtime by default in Spark 3.0. I changed the UDF creation in ShortestPath to use Java UDF with SQL types to bypass it.
* Update patterns.scala to avoid a compile time warning.
* Update build.sbt to show all deprecation/feature warnings.
* Update log4j to hide warnings from CacheManager during tests.