### PR TITLE
Quote column names with backticks

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -882,7 +882,8 @@ object GraphFrame extends Serializable with Logging {
    * Note: This can be replaced with org.apache.spark.sql.catalyst.util.QuotingUtils.quoteIfNeeded
    * once support for Spark 3 has been dropped
    */
-  private[graphframes] def quote(column: String): String = s"`$column`"
+  private[graphframes] def quote(column: String): String =
+    s"`${column.replace("`", "``")}`"
 
   /**
    * Helper for column names containing a dot. Quotes the given column name with backticks to

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -55,11 +55,11 @@ class GraphFrame private (
   override def toString: String = {
     // We call select on the vertices and edges to ensure that ID, SRC, DST always come first
     // in the printed schema.
-    val vCols = (ID +: vertices.columns.filter(_ != ID).toIndexedSeq).map(quote).map(c => col(c))
+    val vCols = (ID +: vertices.columns.filter(_ != ID).toIndexedSeq).map(quote).map(col)
     val eCols =
       (SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq)
         .map(quote)
-        .map(c => col(c))
+        .map(col)
     val v = vertices.select(vCols.toSeq: _*).toString
     val e = edges.select(eCols.toSeq: _*).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -878,6 +878,9 @@ object GraphFrame extends Serializable with Logging {
   /**
    * Helper for column names containing a dot. Quotes the given column name with backticks to
    * avoid further parsing.
+   *
+   * Note: This can be replaced with org.apache.spark.sql.catalyst.util.QuotingUtils.quoteIfNeeded
+   * once support for Spark 3 has been dropped
    */
   private[graphframes] def quote(column: String): String = s"`$column`"
 
@@ -885,6 +888,9 @@ object GraphFrame extends Serializable with Logging {
    * Helper for column names containing a dot. Quotes the given column name with backticks to
    * avoid further parsing. The column name can be given in segments, e.g. quote("col", "field")
    * representing column "col.field", which returns "`col`.`field`".
+   *
+   * Note: This can be replaced with org.apache.spark.sql.catalyst.util.QuotingUtils.quoted once
+   * support for Spark 3 has been dropped
    */
   private[graphframes] def quote(columnSegments: String*): String =
     columnSegments.map(quote).mkString(".")

--- a/src/main/scala/org/graphframes/lib/GraphXConversions.scala
+++ b/src/main/scala/org/graphframes/lib/GraphXConversions.scala
@@ -103,7 +103,7 @@ private[graphframes] object GraphXConversions {
     val renamedSubfields = origSubfields.zip(fieldNames).map { case (orig, newName) =>
       orig.as(newName)
     }
-    val otherFields = df.schema.fieldNames.filter(_ != structName).map(col)
+    val otherFields = df.schema.fieldNames.filter(_ != structName).map(quote).map(col)
     if (renamedSubfields.isEmpty) {
       // Do not attempt to add an empty structure.
       df.select(otherFields.toSeq: _*)
@@ -114,7 +114,7 @@ private[graphframes] object GraphXConversions {
   }
 
   private def drop(df: DataFrame, cols: String*): DataFrame = {
-    val remainingCols = df.schema.map(_.name).filterNot(cols.contains).map(n => df(n))
+    val remainingCols = df.schema.map(_.name).filterNot(cols.contains).map(quote).map(n => df(n))
     df.select(remainingCols: _*)
   }
 
@@ -122,8 +122,8 @@ private[graphframes] object GraphXConversions {
   private def unpackStructFields(df: DataFrame): DataFrame = {
     val cols = df.schema.flatMap {
       case StructField(fname, dt: StructType, nullable, meta) =>
-        dt.iterator.map(sub => col(s"$fname.${sub.name}").as(sub.name))
-      case f => Seq(col(f.name))
+        dt.iterator.map(sub => col(quote(fname, sub.name)).as(sub.name))
+      case f => Seq(col(quote(f.name)))
     }
     df.select(cols: _*)
   }

--- a/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types.{IntegerType, MapType}
 
 import org.graphframes.GraphFrame
+import org.graphframes.GraphFrame.quote
 
 /**
  * Computes shortest paths from every vertex to the given set of landmark vertices. Note that this
@@ -90,7 +91,7 @@ private object ShortestPaths {
       val mapToLandmark = udf(func, MapType(idType, IntegerType, false))
       mapToLandmark(col(DISTANCE_ID))
     }
-    val cols = graph.vertices.columns.map(col) :+ distanceCol.as(DISTANCE_ID)
+    val cols = graph.vertices.columns.map(quote).map(col) :+ distanceCol.as(DISTANCE_ID)
     g.vertices.select(cols.toSeq: _*)
   }
 

--- a/src/main/scala/org/graphframes/lib/TriangleCount.scala
+++ b/src/main/scala/org/graphframes/lib/TriangleCount.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.{array, col, explode, when}
 
 import org.graphframes.GraphFrame
-import org.graphframes.GraphFrame.{DST, ID, LONG_DST, LONG_SRC, SRC}
+import org.graphframes.GraphFrame.{DST, ID, LONG_DST, LONG_SRC, SRC, quote}
 
 /**
  * Computes the number of triangles passing through each vertex.
@@ -69,7 +69,7 @@ private object TriangleCount {
     val countsCol = when(col("count").isNull, 0L).otherwise(col("count"))
     val newV = v
       .join(triangleCounts, v(ID) === triangleCounts(ID), "left_outer")
-      .select((countsCol.as(COUNT_ID) +: v.columns.map(v.apply)).toSeq: _*)
+      .select((countsCol.as(COUNT_ID) +: v.columns.map(quote).map(v.apply)).toSeq: _*)
     newV
   }
 

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -27,7 +27,7 @@ import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{IntegerType, StringType}
+import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructField, StructType}
 import org.apache.spark.storage.StorageLevel
 
 import com.google.common.io.Files
@@ -80,6 +80,19 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     }
   }
 
+  test("construction from DataFrames with dots in column names") {
+    val g = GraphFrame(
+      vertices.withColumnRenamed("name", "a.name"),
+      edges.withColumnRenamed("action", "the.action"))
+    g.vertices.collect().foreach { case Row(id: Long, name: String) =>
+      assert(localVertices(id) === name)
+    }
+    g.edges.collect().foreach { case Row(src: Long, dst: Long, action: String) =>
+      assert(localEdges((src, dst)) === action)
+    }
+    g.pageRank.maxIter(10).run()
+  }
+
   test("construction from edge DataFrame") {
     val g = GraphFrame.fromEdges(edges)
     assert(g.vertices.columns === Array("id"))
@@ -98,6 +111,24 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
   }
 
   test("construction from GraphX") {
+    val vv: RDD[(Long, String)] = vertices.rdd.map { case Row(id: Long, name: String) =>
+      (id, name)
+    }
+    val ee: RDD[Edge[String]] = edges.rdd.map { case Row(src: Long, dst: Long, action: String) =>
+      Edge(src, dst, action)
+    }
+    val g = Graph(vv, ee)
+    val gf = GraphFrame.fromGraphX(g)
+    gf.vertices.select("id", "attr").collect().foreach { case Row(id: Long, name: String) =>
+      assert(localVertices(id) === name)
+    }
+    gf.edges.select("src", "dst", "attr").collect().foreach {
+      case Row(src: Long, dst: Long, action: String) =>
+        assert(localEdges((src, dst)) === action)
+    }
+  }
+
+  test("construction from GraphX with dots in column names") {
     val vv: RDD[(Long, String)] = vertices.rdd.map { case Row(id: Long, name: String) =>
       (id, name)
     }
@@ -265,6 +296,20 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       assert(empty.degrees.count() === 0L)
       assert(empty.triplets.count() === 0L)
     }
+  }
+
+  test("nestAsCol with dots in column names") {
+    val df = vertices.withColumnRenamed("name", "a.name")
+    val col = nestAsCol(df, "attr")
+    assert(
+      df.select(col).schema === StructType(
+        Seq(
+          StructField(
+            "attr",
+            StructType(Seq(
+              StructField("id", LongType, nullable = false),
+              StructField("a.name", StringType, nullable = true))),
+            nullable = false))))
   }
 
   test("skewed long ID assignments") {

--- a/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -141,24 +141,6 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     }
   }
 
-  test("construction from GraphX with dots in column names") {
-    val vv: RDD[(Long, String)] = vertices.rdd.map { case Row(id: Long, name: String) =>
-      (id, name)
-    }
-    val ee: RDD[Edge[String]] = edges.rdd.map { case Row(src: Long, dst: Long, action: String) =>
-      Edge(src, dst, action)
-    }
-    val g = Graph(vv, ee)
-    val gf = GraphFrame.fromGraphX(g)
-    gf.vertices.select("id", "attr").collect().foreach { case Row(id: Long, name: String) =>
-      assert(localVertices(id) === name)
-    }
-    gf.edges.select("src", "dst", "attr").collect().foreach {
-      case Row(src: Long, dst: Long, action: String) =>
-        assert(localEdges((src, dst)) === action)
-    }
-  }
-
   test("convert to GraphX: Long IDs") {
     val gf = GraphFrame(vertices, edges)
     val g = gf.toGraphX

--- a/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
@@ -106,4 +106,11 @@ class ShortestPathsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     doTest(Some(vertices))
   }
 
+  test("Test vertices with backquote in column name") {
+    val verticeSeq =
+      Seq((1L, "one"), (2L, "two"), (3L, "three"), (4L, "four"), (5L, "five"), (6L, "six"))
+    val vertices = sqlContext.createDataFrame(verticeSeq).toDF("id", "a `name`")
+    doTest(Some(vertices))
+  }
+
 }

--- a/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ShortestPathsSuite.scala
@@ -17,30 +17,47 @@
 
 package org.graphframes.lib
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.DataTypes
 
+import org.graphframes.GraphFrame.quote
 import org.graphframes._
 
 class ShortestPathsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
   test("Simple test") {
+    doTest()
+  }
+
+  def doTest(vertices: Option[DataFrame] = Option.empty): Unit = {
+    val spark = this.spark
+    import spark.implicits._
+
     val edgeSeq = Seq((1, 2), (1, 5), (2, 3), (2, 5), (3, 4), (4, 5), (4, 6))
       .flatMap { case e =>
         Seq(e, e.swap)
       }
       .map { case (src, dst) => (src.toLong, dst.toLong) }
     val edges = spark.createDataFrame(edgeSeq).toDF("src", "dst")
-    val graph = GraphFrame.fromEdges(edges)
+    val graph = vertices.map(GraphFrame(_, edges)).getOrElse(GraphFrame.fromEdges(edges))
 
     // Ground truth
-    val shortestPaths = Set(
+    val shortestPaths = Seq(
       (1, Map(1 -> 0, 4 -> 2)),
       (2, Map(1 -> 1, 4 -> 2)),
       (3, Map(1 -> 2, 4 -> 1)),
       (4, Map(1 -> 2, 4 -> 0)),
       (5, Map(1 -> 1, 4 -> 1)),
-      (6, Map(1 -> 3, 4 -> 1)))
+      (6, Map(1 -> 3, 4 -> 1))).toDF("id", "distances")
+    val expectedCols = vertices.map(_.columns.toSeq).getOrElse(Seq("id")) :+ "distances"
+    val expected = vertices
+      .foldLeft(shortestPaths) { case (shortestPaths, vertices) =>
+        shortestPaths.join(vertices, "id")
+      }
+      .select(expectedCols.map(quote).map(col): _*)
+      .collect()
+      .toSet
 
     val landmarks = Seq(1, 4).map(_.toLong)
     val v2 = graph.shortestPaths.landmarks(landmarks).run()
@@ -50,11 +67,8 @@ class ShortestPathsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       v2.schema,
       "distances",
       DataTypes.createMapType(v2.schema("id").dataType, DataTypes.IntegerType, false))
-    val newVs = v2.select("id", "distances").collect().toSeq
-    val results = newVs.map { case Row(id: Long, spMap: Map[Long, Int] @unchecked) =>
-      (id, spMap)
-    }
-    assert(results.toSet === shortestPaths)
+    val results = v2.collect().toSet
+    assert(results === expected)
   }
 
   test("friends graph") {
@@ -76,6 +90,20 @@ class ShortestPathsSuite extends SparkFunSuite with GraphFrameTestSparkContext {
       }
       .toSet
     assert(results === expected)
+  }
+
+  test("Test vertices with column name") {
+    val verticeSeq =
+      Seq((1L, "one"), (2L, "two"), (3L, "three"), (4L, "four"), (5L, "five"), (6L, "six"))
+    val vertices = sqlContext.createDataFrame(verticeSeq).toDF("id", "name")
+    doTest(Some(vertices))
+  }
+
+  test("Test vertices with dot column name") {
+    val verticeSeq =
+      Seq((1L, "one"), (2L, "two"), (3L, "three"), (4L, "four"), (5L, "five"), (6L, "six"))
+    val vertices = sqlContext.createDataFrame(verticeSeq).toDF("id", "a.name")
+    doTest(Some(vertices))
   }
 
 }


### PR DESCRIPTION
This guards against columns that contain dots. These column names must be quoted to avoid that Spark parses them again.

Fixes following exception when your vertices DataFrame contains columns with dots (e.g. `"a.name"`):

```
Cannot resolve column name "a.name" among (id, a.name); did you mean to quote the `a.name` column?;
org.apache.spark.sql.AnalysisException: Cannot resolve column name "a.name" among (id, a.name); did you mean to quote the `a.name` column?;
	at org.apache.spark.sql.Dataset.$anonfun$resolve$1(Dataset.scala:270)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.Dataset.resolve(Dataset.scala:263)
	at org.apache.spark.sql.Dataset.col(Dataset.scala:1353)
	at org.apache.spark.sql.Dataset.apply(Dataset.scala:1320)
	at org.graphframes.GraphFrame$.$anonfun$nestAsCol$1(GraphFrame.scala:820)
	...
```

Fixes this issue also in other places.