### PR TITLE
Correct the order of the analogy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ serialization, and highly expressive graph queries.
 
 # What are GraphFrames?
 
-*GraphX is to RDDs as GraphFrames are to DataFrames.*
+*GraphFrames are to DataFrames as GraphX is to RDDs.*
 
 GraphFrames represent graphs: vertices (e.g., users) and edges (e.g., relationships between users).
 If you are familiar with [GraphX](http://spark.apache.org/docs/latest/graphx-programming-guide.html),


### PR DESCRIPTION
When making an analogy (A is to a as B is to b), the first part (A) is the part you _don't know_ and the second part (B) is the part you know.

This sentence is trying to explain GraphFrames to people who already know GraphX, so GraphX is last in the analogy.