### PR TITLE
Extend to Spark 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ cache:
 matrix:
   include:
     - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.7 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.0.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.0.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.1.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
 
 before_install:
   - ./bin/download_travis_dependencies.sh

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ resolvers += "Spark snapshot repository" at "https://repository.apache.org/snaps
 val sparkVer = sys.props.getOrElse("spark.version", "3.0.0")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
+  case "3.1" => "2.12.11"
   case "3.0" => "2.12.11"
   case "2.4" => "2.11.12"
   case _ => throw new IllegalArgumentException(s"Unsupported Spark version: $sparkVer.")

--- a/dev/release.py
+++ b/dev/release.py
@@ -39,7 +39,7 @@ def verify(prompt, interactive):
 @click.option("--publish-docs", type=bool, default=PUBLISH_DOCS_DEFAULT, show_default=True,
               help="Publish docs to github-pages.")
 @click.option("--spark-version", multiple=True, show_default=True,
-              default=["2.4.6", "3.0.0"])
+              default=["2.4.7", "3.0.2", "3.1.1"])
 def main(release_version, next_version, publish_to, no_prompt, git_remote, publish_docs,
          spark_version):
     interactive = not no_prompt


### PR DESCRIPTION
GraphFrames work fine with Spark 3.1, so I think it should also support the latest Spark version.