### PR TITLE
Extend to Spark 3.2, upgrade to latest Spark patch versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ cache:
 
 matrix:
   include:
-    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.7 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.0.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
-    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.1.1 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.11.12 SPARK_VERSION=2.4.8 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.0.3 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.1.2 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
+    - env: PYSPARK_PYTHON=python3 SCALA_VERSION=2.12.11 SPARK_VERSION=3.2.0 SPARK_BUILD="spark-${SPARK_VERSION}-bin-hadoop2.7"
 
 before_install:
   - ./bin/download_travis_dependencies.sh

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ import ReleaseTransformations._
 
 resolvers += "Spark snapshot repository" at "https://repository.apache.org/snapshots/"
 
-val sparkVer = sys.props.getOrElse("spark.version", "3.0.2")
+val sparkVer = sys.props.getOrElse("spark.version", "3.0.3")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
+  case "3.2" => "2.12.11"
   case "3.1" => "2.12.11"
   case "3.0" => "2.12.11"
   case "2.4" => "2.11.12"

--- a/dev/release.py
+++ b/dev/release.py
@@ -39,7 +39,7 @@ def verify(prompt, interactive):
 @click.option("--publish-docs", type=bool, default=PUBLISH_DOCS_DEFAULT, show_default=True,
               help="Publish docs to github-pages.")
 @click.option("--spark-version", multiple=True, show_default=True,
-              default=["2.4.7", "3.0.2", "3.1.1"])
+              default=["2.4.8", "3.0.3", "3.1.2", "3.2.0"])
 def main(release_version, next_version, publish_to, no_prompt, git_remote, publish_docs,
          spark_version):
     interactive = not no_prompt


### PR DESCRIPTION
Spark 3.2 is being released, Graphframes works well with it.