### PR TITLE
Upgrade to latest spark versions 3.3.0, 3.2.2 and 3.1.3

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,9 +6,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - spark-version: 3.2.0
+          - spark-version: 3.3.0
             scala-version: 2.12.12
-          - spark-version: 3.1.2
+          - spark-version: 3.2.2
+            scala-version: 2.12.12
+          - spark-version: 3.1.3
             scala-version: 2.12.12
             python-version: 3.8
           - spark-version: 3.0.3

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -6,9 +6,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - spark-version: 3.2.0
+          - spark-version: 3.3.0
             scala-version: 2.12.12
-          - spark-version: 3.1.2
+          - spark-version: 3.2.2
+            scala-version: 2.12.12
+          - spark-version: 3.1.3
             scala-version: 2.12.12
           - spark-version: 3.0.3
             scala-version: 2.12.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 
 # Install Spark and update env variables.
 ENV SCALA_VERSION 2.12.15
-ENV SPARK_VERSION "3.2.0"
+ENV SPARK_VERSION "3.3.0"
 ENV SPARK_BUILD "spark-${SPARK_VERSION}-bin-hadoop3.2"
 ENV SPARK_BUILD_URL "https://dist.apache.org/repos/dist/release/spark/spark-${SPARK_VERSION}/${SPARK_BUILD}.tgz"
 RUN wget --quiet "$SPARK_BUILD_URL" -O /tmp/spark.tgz && \

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,10 @@ import ReleaseTransformations._
 
 resolvers += "Spark snapshot repository" at "https://repository.apache.org/snapshots/"
 
-val sparkVer = sys.props.getOrElse("spark.version", "3.2.0")
+val sparkVer = sys.props.getOrElse("spark.version", "3.3.0")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
+  case "3.3" => "2.12.15"
   case "3.2" => "2.12.15"
   case "3.1" => "2.12.15"
   case "3.0" => "2.12.15"

--- a/dev/release.py
+++ b/dev/release.py
@@ -39,7 +39,7 @@ def verify(prompt, interactive):
 @click.option("--publish-docs", type=bool, default=PUBLISH_DOCS_DEFAULT, show_default=True,
               help="Publish docs to github-pages.")
 @click.option("--spark-version", multiple=True, show_default=True,
-              default=["2.4.8", "3.0.3", "3.1.2", "3.2.0"])
+              default=["2.4.8", "3.0.3", "3.1.3", "3.2.2", "3.3.0"])
 def main(release_version, next_version, publish_to, no_prompt, git_remote, publish_docs,
          spark_version):
     interactive = not no_prompt


### PR DESCRIPTION
This add CI builds for spark 3.3.0 and updates to 3.2.2 and 3.1.3.

The new build for 3.3.0 required some small changes in the testsuite for it to run without failures.