### PR TITLE
Add support for scala 2.13

### DIFF
--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -7,9 +7,13 @@ jobs:
       matrix:
         include:
           - spark-version: 3.3.2
+            scala-version: 2.13.10
+          - spark-version: 3.3.2
             scala-version: 2.12.12
           - spark-version: 3.2.3
             scala-version: 2.12.12
+          - spark-version: 3.2.3
+            scala-version: 2.13.10
           - spark-version: 3.1.3
             scala-version: 2.12.12
           - spark-version: 3.0.3

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ val defaultScalaVer = sparkBranch match {
 }
 val scalaVer = sys.props.getOrElse("scala.version", defaultScalaVer)
 val defaultScalaTestVer = scalaVer match {
-  case s if s.startsWith("2.12") => "3.0.8"
+  case s if s.startsWith("2.12") || s.startsWith("2.13") => "3.0.8"
   case s if s.startsWith("2.11") => "2.2.6" // scalatest_2.11 does not have 2.0 published
 }
 

--- a/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -54,7 +54,7 @@ class ShortestPaths private[graphframes] (private val graph: GraphFrame) extends
    * The list of landmark vertex ids. Shortest paths will be computed to each landmark.
    */
   def landmarks(value: util.ArrayList[Any]): this.type = {
-    landmarks(value.asScala)
+    landmarks(value.asScala.toSeq)
   }
 
   def run(): DataFrame = {


### PR DESCRIPTION
Only adds scala CI builds as I don't belive there is any pre-built
pyspark release using scala 2.13.
