### PR TITLE
Python: Replace SQLContext with SparkSession

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,9 +16,6 @@ jobs:
           - spark-version: 3.0.3
             scala-version: 2.12.12
             python-version: 3.8
-          - spark-version: 2.4.8
-            scala-version: 2.11.12
-            python-version: 3.7
     runs-on: ubuntu-20.04
     env:
       # define Java options for both official sbt and sbt-extras

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -14,8 +14,6 @@ jobs:
             scala-version: 2.12.12
           - spark-version: 3.0.3
             scala-version: 2.12.12
-          - spark-version: 2.4.8
-            scala-version: 2.11.12
     runs-on: ubuntu-20.04
     env:
       # define Java options for both official sbt and sbt-extras

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ val defaultScalaVer = sparkBranch match {
   case "3.2" => "2.12.15"
   case "3.1" => "2.12.15"
   case "3.0" => "2.12.15"
-  case "2.4" => "2.11.12"
   case _ => throw new IllegalArgumentException(s"Unsupported Spark version: $sparkVer.")
 }
 val scalaVer = sys.props.getOrElse("scala.version", defaultScalaVer)

--- a/dev/release.py
+++ b/dev/release.py
@@ -39,7 +39,7 @@ def verify(prompt, interactive):
 @click.option("--publish-docs", type=bool, default=PUBLISH_DOCS_DEFAULT, show_default=True,
               help="Publish docs to github-pages.")
 @click.option("--spark-version", multiple=True, show_default=True,
-              default=["2.4.8", "3.0.3", "3.1.3", "3.2.2", "3.3.0"])
+              default=["3.0.3", "3.1.3", "3.2.2", "3.3.0"])
 def main(release_version, next_version, publish_to, no_prompt, git_remote, publish_docs,
          spark_version):
     interactive = not no_prompt

--- a/python/graphframes/examples/belief_propagation.py
+++ b/python/graphframes/examples/belief_propagation.py
@@ -17,14 +17,12 @@
 
 import math
 
-from pyspark import SparkConf, SparkContext
-from pyspark.sql import SQLContext, functions as sqlfunctions, types
-
+# Import subpackage examples here explicitly so that
+# this module can be run directly with spark-submit.
+import graphframes.examples
 from graphframes import GraphFrame
 from graphframes.lib import AggregateMessages as AM
-# Import subpackage examples here explicitly so that this module can be
-# run directly with spark-submit.
-import graphframes.examples
+from pyspark.sql import SparkSession, functions as sqlfunctions, types
 
 __all__ = ['BeliefPropagation']
 
@@ -151,13 +149,11 @@ class BeliefPropagation(object):
 
 def main():
     """Run the belief propagation algorithm for an example problem."""
-    # setup context
-    conf = SparkConf().setAppName("BeliefPropagation example")
-    sc = SparkContext.getOrCreate(conf)
-    sql = SQLContext.getOrCreate(sc)
+    # setup spark session
+    spark = SparkSession.builder.appName("BeliefPropagation example").getOrCreate()
 
     # create graphical model g of size 3 x 3
-    g = graphframes.examples.Graphs(sql).gridIsingModel(3)
+    g = graphframes.examples.Graphs(spark).gridIsingModel(3)
     print("Original Ising model:")
     g.vertices.show()
     g.edges.show()
@@ -171,7 +167,8 @@ def main():
     print("Done with BP. Final beliefs after {} iterations:".format(numIter))
     beliefs.show()
 
-    sc.stop()
+    spark.stop()
+
 
 if __name__ == '__main__':
     main()

--- a/python/graphframes/examples/graphs.py
+++ b/python/graphframes/examples/graphs.py
@@ -27,18 +27,17 @@ __all__ = ['Graphs']
 class Graphs(object):
     """Example GraphFrames for testing the API
 
-    :param sqlContext: SQLContext
+    :param spark: SparkSession
     """
 
-    def __init__(self, sqlContext):
-        self._sql = sqlContext
-        self._sc = sqlContext._sc
+    def __init__(self, spark):
+        self._spark = spark
+        self._sc = spark._sc
 
     def friends(self):
         """A GraphFrame of friends in a (fake) social network."""
-        sqlContext = self._sql
         # Vertex DataFrame
-        v = sqlContext.createDataFrame([
+        v = self._spark.createDataFrame([
             ("a", "Alice", 34),
             ("b", "Bob", 36),
             ("c", "Charlie", 30),
@@ -47,7 +46,7 @@ class Graphs(object):
             ("f", "Fanny", 36)
         ], ["id", "name", "age"])
         # Edge DataFrame
-        e = sqlContext.createDataFrame([
+        e = self._spark.createDataFrame([
             ("a", "b", "friend"),
             ("b", "c", "follow"),
             ("c", "b", "follow"),
@@ -92,7 +91,7 @@ class Graphs(object):
                 .format(n))
 
         # create coodinates grid
-        coordinates = self._sql.createDataFrame(
+        coordinates = self._spark.createDataFrame(
             itertools.product(range(n), range(n)),
             schema=('i', 'j'))
 

--- a/python/graphframes/lib/aggregate_messages.py
+++ b/python/graphframes/lib/aggregate_messages.py
@@ -16,7 +16,7 @@
 #
 
 from pyspark import SparkContext
-from pyspark.sql import DataFrame, functions as sqlfunctions
+from pyspark.sql import DataFrame, functions as sqlfunctions, SparkSession
 
 
 def _java_api(jsc):
@@ -77,7 +77,7 @@ class AggregateMessages(object):
         WARNING: This is NOT the same as `DataFrame.cache()`.
                  The original DataFrame will NOT be cached.
         """
-        sqlContext = df.sql_ctx
-        jvm_gf_api = _java_api(sqlContext._sc)
+        spark = SparkSession.getActiveSession()
+        jvm_gf_api = _java_api(spark._sc)
         jdf = jvm_gf_api.aggregateMessages().getCachedDataFrame(df._jdf)
-        return DataFrame(jdf, sqlContext)
+        return DataFrame(jdf, spark)

--- a/python/graphframes/lib/pregel.py
+++ b/python/graphframes/lib/pregel.py
@@ -19,9 +19,9 @@ import sys
 if sys.version > '3':
     basestring = str
 
-from pyspark.sql import DataFrame
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
-from pyspark.ml.wrapper import JavaWrapper, _jvm
+from pyspark.ml.wrapper import JavaWrapper
 
 
 class Pregel(JavaWrapper):
@@ -169,7 +169,7 @@ class Pregel(JavaWrapper):
 
         :return: the result vertex DataFrame from the final iteration including both original and additional columns.
         """
-        return DataFrame(self._java_obj.run(), self.graph.vertices.sql_ctx)
+        return DataFrame(self._java_obj.run(), SparkSession.getActiveSession())
 
     @staticmethod
     def msg():


### PR DESCRIPTION
According to the [official document](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/SQLContext.html), ```SQLContext``` is deprecated since spark 2.0.  Use ```SparkSession``` instead.

**Notes:**
This MR also removes CI for spark 2.4.8 since it does not support ```SparkSession.getActiveSession()```.  And according to [versioning policy](https://spark.apache.org/versioning-policy.html), spark 2.4.x is EOL and the last version was released in 5 years ago.  There's little meaning to support it.

Closes: #423 