### PR TITLE
Add JVM args to fix sbt.ForkMain error

### DIFF
--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -20,9 +20,10 @@ jobs:
             scala-version: 2.13.5
     runs-on: ubuntu-22.04
     env:
-      # define Java options for both official sbt and sbt-extras
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      # fixing this error after tests success: sbt.ForkMain failed with exit code 134
+      # https://stackoverflow.com/questions/33287424/strange-exception-in-sbt-test
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Dfile.encoding=UTF-8
+      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Dfile.encoding=UTF-8
     steps:
     - uses: actions/checkout@v3
     - uses: olafurpg/setup-scala@v13


### PR DESCRIPTION
Trying to fix:

```
[info] Run completed in 51 seconds, 996 milliseconds.
[info] Total number of tests run: 14
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 14, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[error] Error during tests:
[error] 	Running java with options -classpath ... sbt.ForkMain 42361 failed with exit code 134
[error] (test:test) sbt.TestsFailedException: Tests unsuccessful
```
https://github.com/graphframes/graphframes/actions/runs/6175843274/job/16763535111?pr=437#step:5:722