### PR TITLE
Fix connected component

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,16 +8,6 @@ jobs:
         include:
           - spark-version: 3.5.0
             scala-version: 2.12.18
-            python-version: 3.9
-          - spark-version: 3.4.1
-            scala-version: 2.12.17
-            python-version: 3.9
-          - spark-version: 3.3.3
-            scala-version: 2.12.15
-            python-version: 3.9
-          - spark-version: 3.2.4
-            scala-version: 2.12.15
-            python-version: 3.9
     runs-on: ubuntu-22.04
     env:
       # define Java options for both official sbt and sbt-extras

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -26,7 +26,7 @@ jobs:
           ~/.ivy2/cache
         key: sbt-ivy-cache-spark-${{ matrix.spark-version}}-scala-${{ matrix.scala-version }}
     - name: Assembly
-      run: sbt -v ++${{ matrix.scala-version }} -Dspark.version=${{ matrix.spark-version }} "set test in assembly := {}" assembly
+      run: build/sbt -v ++${{ matrix.scala-version }} -Dspark.version=${{ matrix.spark-version }} "set test in assembly := {}" assembly
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,6 +8,7 @@ jobs:
         include:
           - spark-version: 3.5.0
             scala-version: 2.12.18
+            python-version: 3.9.19
     runs-on: ubuntu-22.04
     env:
       # define Java options for both official sbt and sbt-extras

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -10,18 +10,6 @@ jobs:
             scala-version: 2.13.8
           - spark-version: 3.5.0
             scala-version: 2.12.12
-          - spark-version: 3.4.1
-            scala-version: 2.13.8
-          - spark-version: 3.4.1
-            scala-version: 2.12.12
-          - spark-version: 3.3.3
-            scala-version: 2.13.8
-          - spark-version: 3.3.3
-            scala-version: 2.12.12
-          - spark-version: 3.2.4
-            scala-version: 2.13.5
-          - spark-version: 3.2.4
-            scala-version: 2.12.12
     runs-on: ubuntu-22.04
     env:
       # fixing this error after tests success: sbt.ForkMain failed with exit code 134

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -27,5 +27,5 @@ jobs:
           ~/.ivy2/cache
         key: sbt-ivy-cache-spark-${{ matrix.spark-version}}-scala-${{ matrix.scala-version }}
     - name: Build and Test
-      run: sbt -v ++${{ matrix.scala-version }} -Dspark.version=${{ matrix.spark-version }} coverage test coverageReport
+      run: build/sbt -v ++${{ matrix.scala-version }} -Dspark.version=${{ matrix.spark-version }} coverage test coverageReport
     - uses: codecov/codecov-action@v3

--- a/build.sbt
+++ b/build.sbt
@@ -3,21 +3,15 @@
 
 import ReleaseTransformations._
 
-resolvers += "Spark snapshot repository" at "https://repository.apache.org/snapshots/"
-
 val sparkVer = sys.props.getOrElse("spark.version", "3.5.0")
 val sparkBranch = sparkVer.substring(0, 3)
 val defaultScalaVer = sparkBranch match {
   case "3.5" => "2.12.18"
-  case "3.4" => "2.12.17"
-  case "3.3" => "2.12.15"
-  case "3.2" => "2.12.15"
   case _ => throw new IllegalArgumentException(s"Unsupported Spark version: $sparkVer.")
 }
 val scalaVer = sys.props.getOrElse("scala.version", defaultScalaVer)
 val defaultScalaTestVer = scalaVer match {
   case s if s.startsWith("2.12") || s.startsWith("2.13") => "3.0.8"
-  case s if s.startsWith("2.11") => "2.2.6" // scalatest_2.11 does not have 2.0 published
 }
 
 sparkVersion := sparkVer

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -314,14 +314,30 @@ object ConnectedComponents extends Logging {
     var converged = false
     var iteration = 1
 
+    def _calcMinNbrSum(minNbrsDF: DataFrame): BigDecimal = {
+      // Taking the sum in DecimalType to preserve precision.
+      // We use 20 digits for long values and Spark SQL will add 10 digits for the sum.
+      // It should be able to handle 200 billion edges without overflow.
+      val (minNbrSum, cnt) = minNbrsDF.select(sum(col(MIN_NBR).cast(DecimalType(20, 0))), count("*")).rdd
+        .map { r =>
+          (r.getAs[BigDecimal](0), r.getLong(1))
+        }.first()
+      if (cnt != 0L && minNbrSum == null) {
+        throw new ArithmeticException(
+          s"""
+             |The total sum of edge src IDs is used to determine convergence during iterations.
+             |However, the total sum at iteration $iteration exceeded 30 digits (1e30),
+             |which should happen only if the graph contains more than 200 billion edges.
+             |If not, please file a bug report at https://github.com/graphframes/graphframes/issues.
+            """.stripMargin)
+      }
+      minNbrSum
+    }
     // compute min neighbors (including self-min)
     var minNbrs1: DataFrame = minNbrs(ee) // src >= min_nbr
       .persist(intermediateStorageLevel)
 
-    var prevSum: BigDecimal = minNbrs1.select(sum(col(MIN_NBR).cast(DecimalType(20, 0))), count("*")).rdd
-      .map { r =>
-        (r.getAs[BigDecimal](0), r.getLong(1))
-      }.first()._1
+    var prevSum: BigDecimal = _calcMinNbrSum(minNbrs1)
 
     while (!converged) {
       // large-star step
@@ -366,22 +382,7 @@ object ConnectedComponents extends Logging {
         .persist(intermediateStorageLevel)
 
       // test convergence
-      // Taking the sum in DecimalType to preserve precision.
-      // We use 20 digits for long values and Spark SQL will add 10 digits for the sum.
-      // It should be able to handle 200 billion edges without overflow.
-      val (currSum, cnt) = minNbrs1.select(sum(col(MIN_NBR).cast(DecimalType(20, 0))), count("*")).rdd
-        .map { r =>
-          (r.getAs[BigDecimal](0), r.getLong(1))
-        }.first()
-      if (cnt != 0L && currSum == null) {
-        throw new ArithmeticException(
-          s"""
-             |The total sum of edge src IDs is used to determine convergence during iterations.
-             |However, the total sum at iteration $iteration exceeded 30 digits (1e30),
-             |which should happen only if the graph contains more than 200 billion edges.
-             |If not, please file a bug report at https://github.com/graphframes/graphframes/issues.
-            """.stripMargin)
-      }
+      val currSum = _calcMinNbrSum(minNbrs1)
       logInfo(s"$logPrefix Sum of assigned components in iteration $iteration: $currSum.")
       if (currSum == prevSum) {
         // This also covers the case when cnt = 0 and currSum is null, which means no edges.


### PR DESCRIPTION
Fix connected component algorithm implementation:

The algorithm is described in this paper: https://dl.acm.org/doi/pdf/10.1145/2670979.2670997

Summary of the algorithm: essentially, the algorithm is doing "large-star" and "small-star" transformations over the graph,
until convergence (i.e. the transformation doesn't change graph structure),

```
graph = input_graph  # input graph each node must has a unique and comparable label number
while (! converged) {
   graph = large_star(graph)
   graph = small_star(graph)
}
```

**large star** transformation:
For each node U, finding the neighbor nodes V that has larger label than node U, and finding the node M that has the minimal label in the set of `{*node_U_neighbor_node_set, node_U}`, for every node V, generate an edge from V to M, the generated edges compose of the "large star" transformation output graph.

**small star** transformation:
For each node U, finding the neighbor nodes V that has smaller label than node U, and finding the node M that has the minimal label in the set of `node_U_neighbor_node_set`, for every node V, generate an edge from V to M, and additionally, generate an edge of U to M, the generated edges compose of the "small star" transformation output graph.

<img width="1124" alt="image" src="https://github.com/graphframes/graphframes/assets/19235986/37686d08-faae-422d-9e87-c617dfb83455">


**Convergence critieria:**

Convergence means large star and small star transformation generates identical output graph, and we can prove that, the output graph has the same component connectivity, and the topology of the graph is the overall graph is a union of disjoint stars, one for each connected component, and each star has a center node with the minimal label in its connected component.

To check if the graph reaches convergence, we can check the sum of all nodes' "minimal label value in set {*neighbor_nodes, self_node}", the sum keeps decreasing for each pass of large-star / small-star transformation, once it stops decreasing, it means the graph reaches convergence, and we can get each node's connectivity component ID by calculating its "minimal label value in set {*neighbor_nodes, self_node}".

So, current graphframe connected component algorithm code has one error in convergence checking, I correct it in this PR.

