### PR TITLE
Update quick-start.md to use latest build of GraphFrames jar

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -30,7 +30,7 @@ We use the `--packages` argument to download the graphframes package and any dep
 <div data-lang="scala"  markdown="1">
 
 {% highlight bash %}
-$ ./bin/spark-shell --packages graphframes:graphframes:0.6.0-spark2.3-s_2.11
+$ ./bin/spark-shell --packages graphframes:graphframes:0.8.3-spark3.5-s_2.12
 {% endhighlight %}
 
 </div>
@@ -38,7 +38,7 @@ $ ./bin/spark-shell --packages graphframes:graphframes:0.6.0-spark2.3-s_2.11
 <div data-lang="python"  markdown="1">
 
 {% highlight bash %}
-$ ./bin/pyspark --packages graphframes:graphframes:0.6.0-spark2.3-s_2.11
+$ ./bin/pyspark --packages graphframes:graphframes:0.8.3-spark3.5-s_2.12
 {% endhighlight %}
 
 </div>


### PR DESCRIPTION
This PR updates the Quickstart documentation to use the latest version. Every long journey starts with one step :)