### PR TITLE
Moved from deprecated MaxPermSize to MaxMetaspaceSize to make build work

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ scalacOptions in (Test, doc) ++= Seq("-groups", "-implicits")
 fork in Test := true
 
 // This and the next line fix a problem with forked run: https://github.com/scalatest/scalatest/issues/770
-javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-XX:MaxPermSize=384m")
+javaOptions in Test ++= Seq("-Xmx2048m", "-XX:ReservedCodeCacheSize=384m", "-XX:MaxMetaspaceSize=384m")
 
 concurrentRestrictions in Global := Seq(
   Tags.limitAll(1))

--- a/build/sbt-launch-lib.bash
+++ b/build/sbt-launch-lib.bash
@@ -117,7 +117,7 @@ get_mem_opts () {
   (( $perm < 4096 )) || perm=4096
   local codecache=$(( $perm / 2 ))
 
-  echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
+  echo "-Xms${mem}m -Xmx${mem}m -XX:MaxMetaspaceSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
 }
 
 require_arg () {


### PR DESCRIPTION
The `build/sbt assembly` build crashes on OpenJDK 21 due to a `MaxPermSize` option in sbt build configuration that was removed in Java 9. Updated it to use `MaxMetaspaceSize` which isn't the same but is the recommended replacement. Build gets through this step once I do so.