### PR TITLE
Upgrade `github actions`

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -17,11 +17,11 @@ jobs:
       SPARK_VERSION: ${{ matrix.spark-version }}
       SCALA_VERSION: ${{ matrix.scala-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: olafurpg/setup-scala@v13
       with:
         java-version: "openjdk@1.11"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.ivy2/cache

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -17,11 +17,11 @@ jobs:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Dfile.encoding=UTF-8
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: olafurpg/setup-scala@v13
       with:
         java-version: "openjdk@1.11"
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: |
           ~/.ivy2/cache


### PR DESCRIPTION
This will upgrade actions/checkout and actions/cache from version 3 to version 4

Release info https://github.com/actions/cache  and https://github.com/actions/checkout
