### PR TITLE
Use vertices SparkSession

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -63,7 +63,7 @@ class GraphFrame(object):
     def __init__(self, v, e):
         self._vertices = v
         self._edges = e
-        self._spark = SparkSession.getActiveSession()
+        self._spark = v.sparkSession
         self._sc = self._spark._sc
         self._jvm_gf_api = _java_api(self._sc)
 


### PR DESCRIPTION
The previous version of the `GraphFrame` class used the vertices SQLContext, when the code was changed to use SparkSession the thread's session was taken, this change can break old working code if the GraphFrame is initialized in a thread that didn't initialized a spark session.
This PR uses the vertices SparkSession so it will work regardless to whether a spark session was initialized on the current thread