### PR TITLE
Fix the bug I introduced previously when adapting `build.sbt` for JDK 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,8 @@ project/plugins/project/
 # intellij
 .idea/
 
+# VSCode
+.vscode
+
 # Mac
 *.DS_Store

--- a/build.sbt
+++ b/build.sbt
@@ -66,9 +66,7 @@ fork in Test := true
 javaOptions in Test ++= Seq(
   "-Xmx2048m",
   "-XX:ReservedCodeCacheSize=384m",
-  "-XX:MaxMetaspaceSize=384m",
-  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
-  "--add-opens=java.base/java.lang=ALL-UNNAMED"
+  "-XX:MaxMetaspaceSize=384m"
 )
 
 concurrentRestrictions in Global := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -64,9 +64,12 @@ fork in Test := true
 
 // This and the next line fix a problem with forked run: https://github.com/scalatest/scalatest/issues/770
 javaOptions in Test ++= Seq(
+  "-XX:+IgnoreUnrecognizedVMOptions",
   "-Xmx2048m",
   "-XX:ReservedCodeCacheSize=384m",
-  "-XX:MaxMetaspaceSize=384m"
+  "-XX:MaxMetaspaceSize=384m",
+  "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+  "--add-opens=java.base/java.lang=ALL-UNNAMED"
 )
 
 concurrentRestrictions in Global := Seq(


### PR DESCRIPTION
JDK 8 support is adequate for now, I believe it is still the recommended version for Spark.