### PR TITLE
Update scala code

### DIFF
--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -708,7 +708,7 @@ object GraphFrame extends Serializable with Logging {
   def fromEdges(e: DataFrame): GraphFrame = {
     val srcs = e.select(e("src").as("id"))
     val dsts = e.select(e("dst").as("id"))
-    val v = srcs.unionAll(dsts).distinct
+    val v = srcs.unionAll(dsts).distinct()
     v.persist(StorageLevel.MEMORY_AND_DISK)
     apply(v, e)
   }

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -803,7 +803,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        WrappedArray.make(s.fieldNames).map(f => col + "." + f).toSeq
+        scala.collection.immutable.ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f).toSeq
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -3,8 +3,8 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -53,8 +53,8 @@ class GraphFrame private(
   override def toString: String = {
     // We call select on the vertices and edges to ensure that ID, SRC, DST always come first
     // in the printed schema.
-    val v = vertices.select(ID, vertices.columns.filter(_ != ID) :_ *).toString
-    val e = edges.select(SRC, DST +: edges.columns.filter(c => c != SRC && c != DST) :_ *).toString
+    val v = vertices.select(ID +: vertices.columns.filter(_ != ID).toIndexedSeq: _*).toString
+    val e = edges.select((SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq): _*).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -53,10 +53,10 @@ class GraphFrame private(
   override def toString: String = {
     // We call select on the vertices and edges to ensure that ID, SRC, DST always come first
     // in the printed schema.
-    val vCols = ID +: vertices.columns.filter(_ != ID).toIndexedSeq
-    val eCols = SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq
-    val v = vertices.select(vCols: _*).toString
-    val e = edges.select(eCols: _*).toString
+    val vCols = (ID +: vertices.columns.filter(_ != ID).toIndexedSeq).map(col)
+    val eCols = (SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq).map(col)
+    val v = vertices.select(vCols.head, vCols.tail: _*).toString
+    val e = edges.select(eCols.head, eCols.tail: _*).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -20,7 +20,6 @@ package org.graphframes
 import java.util.Random
 
 import scala.reflect.runtime.universe.TypeTag
-import scala.collection.mutable.WrappedArray
 
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.sql._

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -802,7 +802,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        s.fieldNames.map(f => col + "." + f)
+        scala.collection.immutable.ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f)
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -814,7 +814,7 @@ object GraphFrame extends Serializable with Logging {
 
   /** Nest all columns within a single StructType column with the given name */
   private[graphframes] def nestAsCol(df: DataFrame, name: String): Column = {
-    struct(df.columns.map(c => df(c)) :_*).as(name)
+    struct(df.columns.map(c => df(c)).toSeq: _*).as(name)
   }
 
   // ========== Motif finding ==========

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -20,6 +20,7 @@ package org.graphframes
 import java.util.Random
 
 import scala.reflect.runtime.universe.TypeTag
+import scala.collection.immutable.ArraySeq
 
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.sql._
@@ -802,7 +803,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        scala.collection.immutable.ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f)
+        ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f)
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -20,7 +20,7 @@ package org.graphframes
 import java.util.Random
 
 import scala.reflect.runtime.universe.TypeTag
-import scala.collection.immutable.ArraySeq
+import scala.collection.mutable.WrappedArray
 
 import org.apache.spark.graphx.{Edge, Graph}
 import org.apache.spark.sql._
@@ -803,7 +803,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f)
+        WrappedArray.make(s.fieldNames).map(f => col + "." + f)
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -803,7 +803,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        WrappedArray.make(s.fieldNames).map(f => col + "." + f)
+        WrappedArray.make(s.fieldNames).map(f => col + "." + f).toSeq
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -53,8 +53,10 @@ class GraphFrame private(
   override def toString: String = {
     // We call select on the vertices and edges to ensure that ID, SRC, DST always come first
     // in the printed schema.
-    val v = vertices.select(ID +: vertices.columns.filter(_ != ID).toIndexedSeq: _*).toString
-    val e = edges.select((SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq): _*).toString
+    val vCols = ID +: vertices.columns.filter(_ != ID).toIndexedSeq
+    val eCols = SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq
+    val v = vertices.select(vCols: _*).toString
+    val e = edges.select(eCols: _*).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
 

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -3,8 +3,8 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -803,7 +803,7 @@ object GraphFrame extends Serializable with Logging {
   private[graphframes] def colStar(df: DataFrame, col: String): Seq[String] = {
     df.schema(col).dataType match {
       case s: StructType =>
-        scala.collection.immutable.ArraySeq.unsafeWrapArray(s.fieldNames).map(f => col + "." + f).toSeq
+        s.fieldNames.map(f => col + "." + f).toIndexedSeq
       case other =>
         throw new RuntimeException(s"Unknown error in GraphFrame. Expected column $col to be" +
           s" StructType, but found type: $other")

--- a/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/src/main/scala/org/graphframes/GraphFrame.scala
@@ -55,8 +55,8 @@ class GraphFrame private(
     // in the printed schema.
     val vCols = (ID +: vertices.columns.filter(_ != ID).toIndexedSeq).map(col)
     val eCols = (SRC +: DST +: edges.columns.filter(c => c != SRC && c != DST).toIndexedSeq).map(col)
-    val v = vertices.select(vCols.head, vCols.tail: _*).toString
-    val e = edges.select(eCols.head, eCols.tail: _*).toString
+    val v = vertices.select(vCols.toSeq: _*).toString
+    val e = edges.select(eCols.toSeq: _*).toString
     "GraphFrame(v:" + v + ", e:" + e + ")"
   }
 

--- a/src/main/scala/org/graphframes/examples/BeliefPropagation.scala
+++ b/src/main/scala/org/graphframes/examples/BeliefPropagation.scala
@@ -129,7 +129,7 @@ object BeliefPropagation {
   def runBPwithGraphX(g: GraphFrame, numIter: Int): GraphFrame = {
     // Choose colors for vertices for BP scheduling.
     val colorG = colorGraph(g)
-    val numColors: Int = colorG.vertices.select("color").distinct.count().toInt
+    val numColors: Int = colorG.vertices.select("color").distinct().count().toInt
 
     // Convert GraphFrame to GraphX, and initialize beliefs.
     val gx0 = colorG.toGraphX
@@ -206,7 +206,7 @@ object BeliefPropagation {
   def runBPwithGraphFrames(g: GraphFrame, numIter: Int): GraphFrame = {
     // Choose colors for vertices for BP scheduling.
     val colorG = colorGraph(g)
-    val numColors: Int = colorG.vertices.select("color").distinct.count().toInt
+    val numColors: Int = colorG.vertices.select("color").distinct().count().toInt
 
     // TODO: Handle vertices without any edges.
 

--- a/src/main/scala/org/graphframes/examples/Graphs.scala
+++ b/src/main/scala/org/graphframes/examples/Graphs.scala
@@ -122,7 +122,7 @@ class Graphs private[graphframes] () {
    */
   def ALSSyntheticData(): GraphFrame = {
     val sc = spark.sparkContext
-    val data = sc.parallelize(als_data).map { line =>
+    val data = sc.parallelize(als_data.toIndexedSeq).map { line =>
       val fields = line.split(",")
       (fields(0).toLong * 2, fields(1).toLong * 2 + 1, fields(2).toDouble)
     }
@@ -150,7 +150,7 @@ class Graphs private[graphframes] () {
       |4,2,5.0
       |4,3,1.0
       |4,4,5.0
-    """.stripMargin.split("\n").map(_.trim).filterNot(_.isEmpty).toIndexedSeq
+    """.stripMargin.split("\n").map(_.trim).filterNot(_.isEmpty)
 
   /**
    * This method generates a grid Ising model with random parameters.

--- a/src/main/scala/org/graphframes/examples/Graphs.scala
+++ b/src/main/scala/org/graphframes/examples/Graphs.scala
@@ -150,7 +150,7 @@ class Graphs private[graphframes] () {
       |4,2,5.0
       |4,3,1.0
       |4,4,5.0
-    """.stripMargin.split("\n").map(_.trim).filterNot(_.isEmpty)
+    """.stripMargin.split("\n").map(_.trim).filterNot(_.isEmpty).toIndexedSeq
 
   /**
    * This method generates a grid Ising model with random parameters.

--- a/src/main/scala/org/graphframes/examples/Graphs.scala
+++ b/src/main/scala/org/graphframes/examples/Graphs.scala
@@ -127,7 +127,7 @@ class Graphs private[graphframes] () {
       (fields(0).toLong * 2, fields(1).toLong * 2 + 1, fields(2).toDouble)
     }
     val edges = spark.createDataFrame(data).toDF("src", "dst", "weight")
-    val vs = data.flatMap(r => r._1 :: r._2 :: Nil).collect().distinct.map(x => Tuple1(x))
+    val vs = data.flatMap(r => r._1 :: r._2 :: Nil).collect().distinct.map(x => Tuple1(x)).toIndexedSeq
     val vertices = spark.createDataFrame(vs).toDF("id")
     GraphFrame(vertices, edges)
   }

--- a/src/main/scala/org/graphframes/lib/BFS.scala
+++ b/src/main/scala/org/graphframes/lib/BFS.scala
@@ -218,7 +218,7 @@ private object BFS extends Logging with Serializable {
         }
       }
       val ordered = paths.columns.sortBy(rank _)
-      paths.select(ordered.map(col): _*)
+      paths.select(ordered.map(col).toSeq: _*)
     } else {
       logInfo(s"GraphFrame.bfs failed to find a path of length <= $maxPathLength.")
       // Return empty DataFrame

--- a/src/main/scala/org/graphframes/lib/GraphXConversions.scala
+++ b/src/main/scala/org/graphframes/lib/GraphXConversions.scala
@@ -104,10 +104,10 @@ private[graphframes] object GraphXConversions {
     val otherFields = df.schema.fieldNames.filter(_ != structName).map(col)
     if (renamedSubfields.isEmpty) {
       // Do not attempt to add an empty structure.
-      df.select(otherFields : _*)
+      df.select(otherFields.toSeq: _*)
     } else {
-      val renamedStruct = struct(renamedSubfields : _*).as(structName)
-      df.select(renamedStruct +: otherFields : _*)
+      val renamedStruct = struct(renamedSubfields.toSeq: _*).as(structName)
+      df.select((renamedStruct +: otherFields).toSeq: _*)
     }
   }
 

--- a/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -19,7 +19,7 @@ package org.graphframes.lib
 
 import java.util
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.graphx.{lib => graphxlib}
 import org.apache.spark.sql.{Column, DataFrame, Row}

--- a/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -91,7 +91,7 @@ private object ShortestPaths {
       mapToLandmark(col(DISTANCE_ID))
     }
     val cols = graph.vertices.columns.map(col) :+ distanceCol.as(DISTANCE_ID)
-    g.vertices.select(cols: _*)
+    g.vertices.select(cols.toSeq: _*)
   }
 
   private val DISTANCE_ID = "distances"

--- a/src/main/scala/org/graphframes/lib/TriangleCount.scala
+++ b/src/main/scala/org/graphframes/lib/TriangleCount.scala
@@ -68,7 +68,7 @@ private object TriangleCount {
     val v = graph.vertices
     val countsCol = when(col("count").isNull, 0L).otherwise(col("count"))
     val newV = v.join(triangleCounts, v(ID) === triangleCounts(ID), "left_outer")
-      .select(countsCol.as(COUNT_ID) +: v.columns.map(v.apply) :_ *)
+      .select((countsCol.as(COUNT_ID) +: v.columns.map(v.apply)).toSeq: _*)
     newV
   }
 


### PR DESCRIPTION
This pull request includes several changes aimed at improving the codebase by ensuring consistency in the use of `toIndexedSeq` and `toSeq` methods, along with some minor refactoring. The most important changes include updates to the `GraphFrame` class and related objects, as well as updates to other classes and objects within the `graphframes` package.

Improvements to `GraphFrame` class and related objects:

* [`src/main/scala/org/graphframes/GraphFrame.scala`](diffhunk://#diff-876a16aa3e52c00605720ff8b8b3f8991b4276d3909af7eeb182edeb4c2ab7b9L55-R58): Modified the `toString` method to use `toIndexedSeq` and `toSeq` for column selection consistency.
* [`src/main/scala/org/graphframes/GraphFrame.scala`](diffhunk://#diff-876a16aa3e52c00605720ff8b8b3f8991b4276d3909af7eeb182edeb4c2ab7b9L711-R713): Updated `fromEdges` method to use `distinct()` instead of `distinct`.
* [`src/main/scala/org/graphframes/GraphFrame.scala`](diffhunk://#diff-876a16aa3e52c00605720ff8b8b3f8991b4276d3909af7eeb182edeb4c2ab7b9L805-R807): Updated `colStar` and `nestAsCol` methods to use `toIndexedSeq` and `toSeq` respectively. [[1]](diffhunk://#diff-876a16aa3e52c00605720ff8b8b3f8991b4276d3909af7eeb182edeb4c2ab7b9L805-R807) [[2]](diffhunk://#diff-876a16aa3e52c00605720ff8b8b3f8991b4276d3909af7eeb182edeb4c2ab7b9L814-R816)

Refactoring in other classes and objects:

* [`src/main/scala/org/graphframes/examples/BeliefPropagation.scala`](diffhunk://#diff-a190dc3d1fa3b92fbbf1d1e72ae86ddd34b0fe544ec7d6753aa991bb01db437eL132-R132): Ensured consistent use of `toInt` conversion after `count()` method in `runBPwithGraphX` and `runBPwithGraphFrames` methods. [[1]](diffhunk://#diff-a190dc3d1fa3b92fbbf1d1e72ae86ddd34b0fe544ec7d6753aa991bb01db437eL132-R132) [[2]](diffhunk://#diff-a190dc3d1fa3b92fbbf1d1e72ae86ddd34b0fe544ec7d6753aa991bb01db437eL209-R209)
* [`src/main/scala/org/graphframes/examples/Graphs.scala`](diffhunk://#diff-474cad9ce631374eb0ca2858b233dec58605d25668cff1b8bdf8351fd4b7879eL125-R130): Updated `ALSSyntheticData` method to use `toIndexedSeq` for data and vertices.
* [`src/main/scala/org/graphframes/lib/BFS.scala`](diffhunk://#diff-0d020041a509db84a47a7d4d7d7f7933bc36f45acb6c77f012129db53e83a1a5L221-R221): Modified `paths.select` to use `toSeq` for column selection.
* [`src/main/scala/org/graphframes/lib/GraphXConversions.scala`](diffhunk://#diff-ac87a38e53638119b82b677fde105dab7297aac59f4915b636b4a6f43bfd4ebbL107-R110): Updated `select` method to use `toSeq` for field selection.
* [`src/main/scala/org/graphframes/lib/ShortestPaths.scala`](diffhunk://#diff-b68d8936565fc8f470b56c8d744afded082d86d429e12d53330b811edc6a17d7L22-R22): Replaced `scala.collection.JavaConverters` with `scala.jdk.CollectionConverters`.
* [`src/main/scala/org/graphframes/lib/ShortestPaths.scala`](diffhunk://#diff-b68d8936565fc8f470b56c8d744afded082d86d429e12d53330b811edc6a17d7L94-R94): Updated `select` method to use `toSeq` for column selection.
* [`src/main/scala/org/graphframes/lib/TriangleCount.scala`](diffhunk://#diff-8244ccbbd0821aee2a3ea450c92e8c2207244e530d7d1bb2077e0afc2416905fL71-R71): Modified `select` method to use `toSeq` for column selection.


This removes warnings when we build. Note we can't use WrappedArray if we will have support for Scala 2.12