### PR TITLE
chore: replace setup-scala action

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -18,9 +18,10 @@ jobs:
       SCALA_VERSION: ${{ matrix.scala-version }}
     steps:
     - uses: actions/checkout@v4
-    - uses: olafurpg/setup-scala@v13
+    - uses: actions/setup-java@v4
       with:
-        java-version: "openjdk@1.11"
+        distribution: "zulu"
+        java-version: "11"
     - uses: actions/cache@v4
       with:
         path: |

--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -18,14 +18,17 @@ jobs:
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC -Dfile.encoding=UTF-8
     steps:
     - uses: actions/checkout@v4
-    - uses: olafurpg/setup-scala@v13
+    - uses: actions/setup-java@v4
       with:
-        java-version: "openjdk@1.11"
+        distribution: "zulu"
+        java-version: "11"
     - uses: actions/cache@v4
       with:
         path: |
           ~/.ivy2/cache
         key: sbt-ivy-cache-spark-${{ matrix.spark-version}}-scala-${{ matrix.scala-version }}
+    - name: Check scalafmt
+      run: build/sbt root/scalafmtCheckAll
     - name: Build and Test
       run: build/sbt -v ++${{ matrix.scala-version }} -Dspark.version=${{ matrix.spark-version }} coverage test coverageReport
     - uses: codecov/codecov-action@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?
- replace outdated `olafurpg/setup-scala` by `setup-java` action
- force the run of the `scalafmtCheckAll` during the CI

### Why are the changes needed?
As described in #514
