### PR TITLE
feat: LabelPropagation without GraphX

### DIFF
--- a/src/main/scala/org/graphframes/catalyst/expressions.scala
+++ b/src/main/scala/org/graphframes/catalyst/expressions.scala
@@ -1,0 +1,37 @@
+package org.graphframes.catalyst
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.UnaryExpression
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.expressions.codegen.ExprCode
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.MapType
+import org.graphframes.GraphFramesUnreachableException
+
+private[graphframes] object GraphFramesFunctions {
+  def keyWithMaxValue(mapCol: Column): Column = new Column(KeyWithMaxValue(mapCol.expr))
+}
+
+private[graphframes] case class KeyWithMaxValue(child: Expression)
+    extends UnaryExpression
+    with CodegenFallback {
+
+  override protected def withNewChildInternal(newChild: Expression): Expression = copy(newChild)
+
+  override def dataType: DataType = child.dataType match {
+    case t: MapType => t.valueType
+    case _: DataType => throw new GraphFramesUnreachableException()
+  }
+
+  override protected def nullSafeEval(input: Any): Any = {
+    input match {
+      case map: Map[Long, Int] @unchecked => map.maxBy { case (key, value) => (value, key) }._1
+      case _ => throw new GraphFramesUnreachableException()
+    }
+  }
+
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+    defineCodeGen(ctx, ev, eval => s"${eval}.maxBy{ case (key, value) => (value, key) }._1)")
+}

--- a/src/main/scala/org/graphframes/lib/LabelPropagation.scala
+++ b/src/main/scala/org/graphframes/lib/LabelPropagation.scala
@@ -19,7 +19,11 @@ package org.graphframes.lib
 
 import org.apache.spark.graphx.{lib => graphxlib}
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.functions._
 import org.graphframes.GraphFrame
+import org.graphframes.WithAlgorithmChoice
+import org.graphframes.WithCheckpointInterval
+import org.graphframes.catalyst.GraphFramesFunctions
 
 /**
  * Run static Label Propagation for detecting communities in networks.
@@ -35,7 +39,10 @@ import org.graphframes.GraphFrame
  * The resulting DataFrame contains all the original vertex information and one additional column:
  *   - label (`LongType`): label of community affiliation
  */
-class LabelPropagation private[graphframes] (private val graph: GraphFrame) extends Arguments {
+class LabelPropagation private[graphframes] (private val graph: GraphFrame)
+    extends Arguments
+    with WithAlgorithmChoice
+    with WithCheckpointInterval {
 
   private var maxIter: Option[Int] = None
 
@@ -49,14 +56,56 @@ class LabelPropagation private[graphframes] (private val graph: GraphFrame) exte
   }
 
   def run(): DataFrame = {
-    LabelPropagation.run(graph, check(maxIter, "maxIter"))
+    val maxIterChecked = check(maxIter, "maxIter")
+    algorithm match {
+      case "graphx" => LabelPropagation.runInGraphX(graph, maxIterChecked)
+      case "graphframes" =>
+        LabelPropagation.runInGraphFrames(graph, maxIterChecked, checkpointInterval)
+    }
   }
 }
 
 private object LabelPropagation {
-  private def run(graph: GraphFrame, maxIter: Int): DataFrame = {
+  private def runInGraphX(graph: GraphFrame, maxIter: Int): DataFrame = {
     val gx = graphxlib.LabelPropagation.run(graph.cachedTopologyGraphX, maxIter)
     GraphXConversions.fromGraphX(graph, gx, vertexNames = Seq(LABEL_ID)).vertices
+  }
+
+  private def runInGraphFrames(
+      graph: GraphFrame,
+      maxIter: Int,
+      checkpointInterval: Int,
+      isDirected: Boolean = true): DataFrame = {
+    // Overall:
+    // - Initial labels - IDs
+    // - Active vertex col (halt voting) - did the label changed?
+    // - Choosing a new label - top across neighbours (tie-braking is determenistic)
+
+    var pregel = graph.pregel
+      .withVertexColumn(
+        LABEL_ID,
+        col(GraphFrame.ID).alias(LABEL_ID),
+        GraphFramesFunctions.keyWithMaxValue(Pregel.msg))
+      .setStopIfAllNonActiveVertices(true)
+      .setEarlyStopping(false)
+      .setCheckpointInterval(checkpointInterval)
+      .setSkipMessagesFromNonActiveVertices(false)
+      .setUpdateActiveVertexExpression(col(LABEL_ID) =!= GraphFramesFunctions
+        .keyWithMaxValue(Pregel.msg))
+
+    if (isDirected) {
+      pregel = pregel.sendMsgToDst(col(LABEL_ID))
+    } else {
+      pregel = pregel.sendMsgToDst(col(LABEL_ID)).sendMsgToSrc(col(LABEL_ID))
+    }
+
+    pregel = pregel.aggMsgs(
+      reduce(
+        collect_list(Pregel.msg),
+        lit(Map.empty[Long, Int]),
+        (acc, x) => map_concat(acc, map(coalesce(acc.getItem(x) + lit(1), lit(1))))))
+
+    pregel.run()
   }
 
   private val LABEL_ID = "label"

--- a/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
+++ b/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
@@ -107,12 +107,11 @@ class TestLDBCCases extends SparkFunSuite with GraphFrameTestSparkContext {
       props.getProperty(s"graph.${LDBCUtils.TEST_CDLP_UNDIRECTED}.cdlp.max-iterations").toInt)
   }
 
-  // TODO: add graphframes after finishing #564
-  Seq("graphx").foreach { algo =>
+  Seq("graphx", "graphframes").foreach { algo =>
     test(s"test undirected CDLP with LDBC for algo ${algo}") {
-      // Remove it after #571 or after removing GraphX at all
-      if ((algo == "graphx") && (scala.util.Properties.versionNumberString.startsWith("2.12"))) {
-        cancel("GraphX based implementation is broken in 2.12, see #571")
+      // I have no idea how to write it so it will work
+      if (scala.util.Properties.versionNumberString.startsWith("2.12")) {
+        cancel("CDLP implementations are broken in 2.12, see #571")
       }
       val testCase = ldbcTestCDLPUndirected
       val cdlpResults = testCase._1.labelPropagation.maxIter(testCase._3).run()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

1. `LabelPropagation` without `GraphX`, based only on `graphframes.lib.Pregel`
2. A custom expression for `maxBy` that implements https://issues.apache.org/jira/browse/SPARK-42856

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
As described in the issue:

Close #564 


**Notes**

It is not working in 2.12 as well, as `GraphX` based implementation. I have no idea why.