### PR TITLE
chore: make pytest more robust

### DIFF
--- a/python/tests/test_graphframes.py
+++ b/python/tests/test_graphframes.py
@@ -151,14 +151,14 @@ def test_power_iteration_clustering(spark):
         e=spark.createDataFrame(vertices).toDF("src", "dst", "weight"),
     )
 
-    clusters = [
-        r["cluster"]
+    clusters = {
+        r["id"]: r["cluster"]
         for r in g.powerIterationClustering(k=2, maxIter=40, weightCol="weight")
         .sort("id")
         .collect()
-    ]
+    }
 
-    assert clusters == [0, 0, 0, 0, 1, 0]
+    assert clusters == {0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 0}
 
 
 def test_page_rank(spark):


### PR DESCRIPTION
### What changes were proposed in this pull request?
The tiny change in power-iteration clustering test in PySpark

### Why are the changes needed?
It looks like PySpark Connect does not preserve the ordering of rows due to spark->arrow->python conversion after `collect`
