### PR TITLE
chore: Cleanup assembly and shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val root = (project in file("."))
     commonSetting,
     name := "graphframes",
     moduleName := s"${name.value}-spark$sparkMajorVer",
+    // Export the JAR so that this can be excluded from shading in connect
     exportJars := true,
 
     // Global settings

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val root = (project in file("."))
     commonSetting,
     name := "graphframes",
     moduleName := s"${name.value}-spark$sparkMajorVer",
+    exportJars := true,
 
     // Global settings
     Global / concurrentRestrictions := Seq(Tags.limitAll(1)),

--- a/build.sbt
+++ b/build.sbt
@@ -144,19 +144,8 @@ lazy val connectAssembly = (project in file("graphframes-connect"))
     assembly / test := {},
     assembly / assemblyShadeRules := Seq(
       ShadeRule.rename("com.google.protobuf.**" -> protobufShadingPattern).inAll),
-    assembly / assemblyMergeStrategy := {
-      case PathList("google", "protobuf", xs @ _*) => MergeStrategy.discard
-      case PathList("META-INF", xs @ _*) => MergeStrategy.discard
-      case x if x.endsWith("module-info.class") => MergeStrategy.discard
-      case x => MergeStrategy.first
-    },
-    assembly / assemblyExcludedJars := {
-      val cp = (assembly / fullClasspath).value
-      val allowedPrefixes = Set("protobuf-java")
-      cp.filter { f =>
-        !allowedPrefixes.exists(prefix => f.data.getName.startsWith(prefix))
-      }
-    },
+    // Don't actually shade anything, we just need to rename the protobuf packages to what's bundled with Spark
+    assembly / assemblyExcludedJars := (assembly / fullClasspath).value,
     publish / skip := true,
     Compile / packageBin := assembly.value,
     Test / packageBin / publishArtifact := false,

--- a/python/dev/build_jar.py
+++ b/python/dev/build_jar.py
@@ -16,9 +16,9 @@ def build(spark_versions: Sequence[str] = ["3.5.5"]):
             sbt_executable,
             f"-Dspark.version={spark_version}",
             "clean",
-            "assembly",
+            "package",
             "connect/clean",
-            "connect/assembly"
+            "connect/package"
         ]
         sbt_build = subprocess.Popen(
             sbt_build_command,

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -36,7 +36,7 @@ def get_gf_jar_locations() -> Tuple[str, str]:
     core_jar: Optional[str] = None
     connect_jar: Optional[str] = None
 
-    for pp in core_dir.glob(f"graphframes-spark{spark_major_version}-*.jar"):
+    for pp in core_dir.glob(f"graphframes-spark{spark_major_version}*.jar"):
         assert isinstance(pp, pathlib.PosixPath)  # type checking
         core_jar = str(pp.absolute())
 
@@ -45,7 +45,7 @@ def get_gf_jar_locations() -> Tuple[str, str]:
             f"Failed to find graphframes jar for Spark {spark_major_version} in {core_dir}"
         )
 
-    for pp in connect_dir.glob(f"graphframes-connect-spark{spark_major_version}-*.jar"):
+    for pp in connect_dir.glob(f"graphframes-connect-spark{spark_major_version}*.jar"):
         assert isinstance(pp, pathlib.PosixPath)  # type checking
         connect_jar = str(pp.absolute())
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -36,7 +36,7 @@ def get_gf_jar_locations() -> Tuple[str, str]:
     core_jar: Optional[str] = None
     connect_jar: Optional[str] = None
 
-    for pp in core_dir.glob("graphframes-assembly-*.jar"):
+    for pp in core_dir.glob(f"graphframes-spark{spark_major_version}-*.jar"):
         assert isinstance(pp, pathlib.PosixPath)  # type checking
         core_jar = str(pp.absolute())
 
@@ -45,7 +45,7 @@ def get_gf_jar_locations() -> Tuple[str, str]:
             f"Failed to find graphframes jar for Spark {spark_major_version} in {core_dir}"
         )
 
-    for pp in connect_dir.glob("graphframes-connect-assembly-*.jar"):
+    for pp in connect_dir.glob(f"graphframes-connect-spark{spark_major_version}-*.jar"):
         assert isinstance(pp, pathlib.PosixPath)  # type checking
         connect_jar = str(pp.absolute())
 

--- a/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
+++ b/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
@@ -11,11 +11,12 @@ import org.graphframes.GraphFrameTestSparkContext
 import org.graphframes.SparkFunSuite
 import org.graphframes.examples.LDBCUtils
 
+import java.io.File
 import java.nio.file._
 import java.util.Properties
 
 class TestLDBCCases extends SparkFunSuite with GraphFrameTestSparkContext {
-  private val resourcesPath = Paths.get(getClass().getResource("/").toURI())
+  private val resourcesPath = Path.of(new File("target").toURI())
   private val unreachableID = 9223372036854775807L
 
   private def readUndirectedUnweighted(pathPrefix: String): GraphFrame = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

Resolves https://github.com/graphframes/graphframes/issues/614

Since the sbt-assembly plugin is meant for creating fat/uber JARs, it doesn't do anything about modifying POMs for published libraries to take into account the things that are shaded. So this creates an intermediate project for the connect shading, and then a final project with the correct dependencies and shaded JAR for actual publishing.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix connect artifact so only protobuf is shaded.