### PR TITLE
fix: try to fix publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val protocVersion = sparkMajorVer match {
 }
 
 ThisBuild / scalaVersion := scalaVer
-ThisBuild / organization := "org.graphframes"
+ThisBuild / organization := "io.graphframes"
 ThisBuild / homepage := Some(url("https://graphframes.io/"))
 ThisBuild / licenses := Seq("Apache-2.0" -> url("https://opensource.org/licenses/Apache-2.0"))
 ThisBuild / scmInfo := Some(
@@ -54,9 +54,6 @@ ThisBuild / developers := List(
     email = "jimwillis95@gmail.com",
     url = url("https://github.com/james-willis"))
 )
-ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
-ThisBuild / sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
-ThisBuild / sonatypeProfileName := "io.graphframes"
 ThisBuild / crossScalaVersions := scalaVersions
 
 // Scalafix configuration

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,4 +17,4 @@ libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.10"
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 // SBT CI Release
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")


### PR DESCRIPTION
### What changes were proposed in this pull request?
TLDR;

- due to sunset of legacy nexus we should use `sbt-ci-release` 1.11+
- starting from 1.11.x there we can't overwrite the namespace (`sonatypeProfileName`)
- the only way is to have `groupId` equal to `io.graphframes` instead of `org.graphframes` (!)

See: https://github.com/sbt/sbt-ci-release/issues/385
See: https://github.com/sbt/sbt-ci-release/issues/375
See: https://central.sonatype.org/publish/requirements/#correct-coordinates

etc.

### Why are the changes needed?
#618 

P.S. I think it won't be hard to migrate (just one line in dependencies), isn't it?
P.P.S. Overall I'm fine to migrate the whole namespace (I mean to change it in the code), but it would so breaking change that maybe it is better to postpone
