### PR TITLE
chore: add useLabelsAsComponents configuration for connected components

### DIFF
--- a/src/main/scala/org/apache/spark/sql/graphframes/GraphFramesConf.scala
+++ b/src/main/scala/org/apache/spark/sql/graphframes/GraphFramesConf.scala
@@ -10,7 +10,7 @@ object GraphFramesConf {
     SQLConf
       .buildConf("spark.graphframes.useLabelsAsComponents")
       .doc(""" Tells the connected components algorithm to use (default: "true") labels as components in the output
-          | DataFrame. If set to "false", randomly generated labels will returned.
+          | DataFrame. If set to "false", randomly generated labels with the data type LONG will returned.
           |""".stripMargin)
       .version("0.9.0")
       .booleanConf

--- a/src/main/scala/org/apache/spark/sql/graphframes/GraphFramesConf.scala
+++ b/src/main/scala/org/apache/spark/sql/graphframes/GraphFramesConf.scala
@@ -6,6 +6,16 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.storage.StorageLevel
 
 object GraphFramesConf {
+  private val USE_LABELS_AS_COMPONENTS =
+    SQLConf
+      .buildConf("spark.graphframes.useLabelsAsComponents")
+      .doc(""" Tells the connected components algorithm to use (default: "true") labels as components in the output
+          | DataFrame. If set to "false", randomly generated labels will returned.
+          |""".stripMargin)
+      .version("0.9.0")
+      .booleanConf
+      .createWithDefault(true)
+
   private val CONNECTED_COMPONENTS_ALGORITHM =
     SQLConf
       .buildConf("spark.graphframes.connectedComponents.algorithm")
@@ -93,4 +103,6 @@ object GraphFramesConf {
       case _ => None
     }
   }
+
+  def getUseLabelsAsComponents: Boolean = get(USE_LABELS_AS_COMPONENTS).get.toBoolean
 }

--- a/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
+++ b/src/main/scala/org/graphframes/lib/ConnectedComponents.scala
@@ -340,7 +340,7 @@ object ConnectedComponents extends Logging {
           vv(ATTR),
           when(ee(SRC).isNull, vv(ID)).otherwise(ee(SRC)).as(COMPONENT),
           col(ATTR + "." + ID).as(ID))
-      val output = if (graph.hasIntegralIdType) {
+      val output = if (graph.hasIntegralIdType || !GraphFramesConf.getUseLabelsAsComponents) {
         indexedLabel
           .select(col(s"$ATTR.*"), col(COMPONENT))
           .persist(intermediateStorageLevel)

--- a/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.storage.StorageLevel
 import org.graphframes.GraphFrame._
 import org.graphframes._
@@ -73,6 +74,25 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     val components = g.connectedComponents.run()
     val expected = (0L until n).map(Set(_)).toSet
     assertComponents(components, expected)
+  }
+
+  test("using labels as components") {
+    val vertices = spark.createDataFrame(Seq("a", "b", "c", "d", "e").map(Tuple1.apply)).toDF(ID)
+    val edges = spark.createDataFrame(Seq.empty[(String, String)]).toDF(SRC, DST)
+    val g = GraphFrame(vertices, edges)
+    val components = g.connectedComponents.run()
+    val expected = Seq("a", "b", "c", "d", "e").map(Set(_)).toSet
+    assertComponents(components, expected)
+  }
+
+  test("don't using labels as components") {
+    spark.conf.set("spark.graphframes.useLabelsAsComponents", "false")
+    val vertices = spark.createDataFrame(Seq("a", "b", "c", "d", "e").map(Tuple1.apply)).toDF(ID)
+    val edges = spark.createDataFrame(Seq.empty[(String, String)]).toDF(SRC, DST)
+    val g = GraphFrame(vertices, edges)
+    val components = g.connectedComponents.run()
+    assert(components.schema("component").dataType == LongType)
+    spark.conf.set("spark.graphframes.useLabelsAsComponents", "true")
   }
 
   test("two connected vertices") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Introduced a new configuration option `spark.graphframes.useLabelsAsComponents` to allow connected components to use labels as components. Updated the logic in `ConnectedComponents` and added relevant test cases for both enabled and disabled configurations.

### Why are the changes needed?
Close #620 
