### PR TITLE
fix: remove version.sbt

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "0.9.0-SNAPSHOT"


### PR DESCRIPTION
### What changes were proposed in this pull request?
- remove `version.sbt`

sbt-ci-release correctly determines the version without this file. Otherwise the release-CI is not working at all, see #635 

### Why are the changes needed?
Close #635 
