### PR TITLE
bug: Let classic python version work without grpc deps

### DIFF
--- a/python/graphframes/graphframe.py
+++ b/python/graphframes/graphframe.py
@@ -35,17 +35,9 @@ from pyspark.sql import SparkSession
 from graphframes.classic.graphframe import GraphFrame as GraphFrameClassic
 from graphframes.lib import Pregel
 
-if __version__[:3] >= "3.4":
-    from graphframes.connect.graphframe_client import GraphFrameConnect
-else:
-
-    class GraphFrameConnect:
-        def __init__(self, *args, **kwargs) -> None:
-            raise ValueError("Unreachable error happened!")
-
-
 if TYPE_CHECKING:
     from pyspark.sql import Column, DataFrame
+    from graphframes.connect.graphframe_client import GraphFrameConnect
 
 
 class GraphFrame:
@@ -67,11 +59,13 @@ class GraphFrame:
     """
 
     @staticmethod
-    def _from_impl(impl: GraphFrameClassic | GraphFrameConnect) -> "GraphFrame":
+    def _from_impl(impl: GraphFrameClassic | 'GraphFrameConnect') -> "GraphFrame":
         return GraphFrame(impl.vertices, impl.edges)
 
     def __init__(self, v: DataFrame, e: DataFrame) -> None:
+        self._impl: GraphFrameClassic | 'GraphFrameConnect'
         if is_remote():
+            from graphframes.connect.graphframe_client import GraphFrameConnect
             self._impl = GraphFrameConnect(v, e)
         else:
             self._impl = GraphFrameClassic(v, e)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

Resolves #646 

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Lazily import connect client to avoid import errors if not trying to use connect. If the user is using connect (i.e. `is_remote()` is true, it will throw an error if there is a dependency issue when creating the graphframe object.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To let the python package work with classic spark without grpc related dependencies installed.