### PR TITLE
feat: S-sized benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ graphframes-connect-databricks/*
 
 # Workspace
 workspace
+
+# JMH (jmh-result.json, jmh-result.csv, etc.)
+jmh-result.*

--- a/benchmarks/src/main/scala/org/graphframes/benchmarks/LDBCBenchmarkSuite.scala
+++ b/benchmarks/src/main/scala/org/graphframes/benchmarks/LDBCBenchmarkSuite.scala
@@ -1,0 +1,138 @@
+package org.graphframes.benchmarks
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import org.graphframes.GraphFrame
+import org.graphframes.examples.LDBCUtils
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+
+class LDBCBenchmarkSuite {
+  private def spark: SparkSession = {
+    SparkSession.getActiveSession match {
+      case Some(session) => session
+      case None =>
+        val spark = SparkSession
+          .builder()
+          .master("local[*]")
+          .appName("GraphFramesBenchmarks")
+          .config("spark.sql.shuffle.partitions", s"${Runtime.getRuntime.availableProcessors()}")
+          .config("spark.driver.memory", "8g")
+          .config("spark.executor.memory", "8g")
+          .getOrCreate()
+
+        spark.sparkContext.setLogLevel("ERROR")
+        spark
+    }
+  }
+
+  private def resourcesPath = Path.of(new File("target").toURI())
+  private def unreachableID = 9223372036854775807L
+
+  @Benchmark
+  @Fork(value = 1)
+  @Warmup(iterations = 1)
+  @Measurement(iterations = 2)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkSP(blackhole: Blackhole): Unit = {
+    LDBCUtils.downloadLDBCIfNotExists(resourcesPath, LDBCUtils.GRAPH500_22)
+    val caseRoot = resourcesPath.resolve(LDBCUtils.GRAPH500_22)
+
+    val expectedResults = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("id", LongType), StructField("distance", LongType))))
+      .csv(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}-BFS").toString)
+
+    val props = new Properties()
+    val stream = Files.newInputStream(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}.properties"))
+    props.load(stream)
+    stream.close()
+
+    val sourceVertex =
+      props.getProperty(s"graph.${LDBCUtils.GRAPH500_22}.bfs.source-vertex").toLong
+
+    val edges = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("src", LongType), StructField("dst", LongType))))
+      .load(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}.e").toString)
+    val vertices = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("id", LongType))))
+      .load(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}.v").toString)
+    val graph = GraphFrame(vertices, edges)
+
+    val spResults = graph.shortestPaths
+      .setUseLocalCheckpoints(true)
+      .landmarks(Seq(sourceVertex))
+      .setCheckpointInterval(1)
+      .setAlgorithm("graphframes")
+      .run()
+      .select(
+        col(GraphFrame.ID),
+        col("distances").getItem(sourceVertex).cast(LongType).alias("got_distance"))
+      .na
+      .fill(Map("got_distance" -> unreachableID))
+
+    val cntOfMismatches = spResults
+      .join(expectedResults, Seq("id"))
+      .filter(col("got_distance") =!= col("distance"))
+      .count()
+    blackhole.consume(assert(cntOfMismatches == 0))
+  }
+
+  @Benchmark
+  @Fork(value = 1)
+  @Warmup(iterations = 1)
+  @Measurement(iterations = 2)
+  @BenchmarkMode(Array(Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  def benchmarkCC(blackhole: Blackhole): Unit = {
+    LDBCUtils.downloadLDBCIfNotExists(resourcesPath, LDBCUtils.GRAPH500_22)
+    val caseRoot = resourcesPath.resolve(LDBCUtils.GRAPH500_22)
+
+    val expectedResults = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("id", LongType), StructField("wcomp", LongType))))
+      .csv(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}-WCC").toString)
+
+    val edges = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("src", LongType), StructField("dst", LongType))))
+      .load(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}.e").toString)
+    val vertices = spark.read
+      .format("csv")
+      .option("header", "false")
+      .schema(StructType(Seq(StructField("id", LongType))))
+      .load(caseRoot.resolve(s"${LDBCUtils.GRAPH500_22}.v").toString)
+    val graph = GraphFrame(vertices, edges)
+
+    val ccResults =
+      graph.connectedComponents.setUseLocalCheckpoints(true).setAlgorithm("graphframes").run()
+    val cntOfMismatches = ccResults
+      .join(expectedResults, Seq("id"))
+      .filter(col("wcomp") =!= col("component"))
+      .count()
+    blackhole.consume(assert(cntOfMismatches == 0))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val scalaVersions = sparkMajorVer match {
 }
 lazy val scalaVer = sys.props.getOrElse("scala.version", scalaVersions(0))
 lazy val defaultScalaTestVer = "3.0.8"
+lazy val jmhVersion = "1.37"
 
 // Some vendors are using an own shading rule for protobuf
 lazy val protobufShadingPattern = sys.props.getOrElse("vendor.name", "oss") match {
@@ -154,3 +155,20 @@ lazy val connect = (project in file("connect"))
     Compile / packageDoc / publishArtifact := true,
     Compile / packageSrc / publishArtifact := true
   )
+
+lazy val benchmarks = (project in file("benchmarks"))
+  .dependsOn(core)
+  .settings(
+    commonSetting,
+    name := "graphframes-benchmarks",
+    publish / skip := true,
+    publishArtifact := false,
+    libraryDependencies ++= Seq(
+      // required for jmh IDEA plugin. Make sure this version matches sbt-jmh version!
+      "org.openjdk.jmh" % "jmh-generator-annprocess" % jmhVersion,
+      // for benchmarks the scope should be runtime
+      "org.apache.spark" %% "spark-graphx" % sparkVer % "runtime" cross CrossVersion.for3Use2_13,
+      "org.apache.spark" %% "spark-sql" % sparkVer % "runtime" cross CrossVersion.for3Use2_13,
+      "org.apache.spark" %% "spark-mllib" % sparkVer % "runtime" cross CrossVersion.for3Use2_13),
+  )
+  .enablePlugins(JmhPlugin)

--- a/core/src/main/scala/org/graphframes/examples/LDBCUtils.scala
+++ b/core/src/main/scala/org/graphframes/examples/LDBCUtils.scala
@@ -17,6 +17,7 @@ object LDBCUtils {
   val TEST_WCC_DIRECTED = "test-wcc-directed"
   val TEST_WCC_UNDIRECTED = "test-wcc-undirected"
   val KGS = "kgs"
+  val GRAPH500_22 = "graph500-22"
 
   private val possibleCaseNames = Set(
     TEST_BFS_DIRECTED,
@@ -27,7 +28,8 @@ object LDBCUtils {
     TEST_PR_UNDIRECTED,
     TEST_WCC_DIRECTED,
     TEST_WCC_UNDIRECTED,
-    KGS)
+    KGS,
+    GRAPH500_22)
 
   private def ldbcURL(caseName: String): URL = new URL(s"${LDBC_URL_PREFIX}${caseName}.tar.zst")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.3")
 
 // SBT CI Release
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+
+// JMH & benchmarking
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
### What changes were proposed in this pull request?
- new `benchmarks` sub-project
- JMH plugin
- S-sized benchmarks for SP and CC (2M vertices, 64M edges)

### Why are the changes needed?
Close #532 

P.S. I'm planning to run benchmarks on the stage of docs-generation and inject results directly to the website.

At the moment on my laptop (i5-1335U, 12 cores, 40 Gb RAM):
```json
[
    {
        "jmhVersion" : "1.37",
        "benchmark" : "org.graphframes.benchmarks.LDBCBenchmarkSuite.benchmarkCC",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jdkVersion" : "17.0.11",
        "vmName" : "OpenJDK 64-Bit Server VM",
        "vmVersion" : "17.0.11+9-LTS",
        "warmupIterations" : 1,
        "warmupTime" : "10 s",
        "warmupBatchSize" : 1,
        "measurementIterations" : 2,
        "measurementTime" : "10 s",
        "measurementBatchSize" : 1,
        "primaryMetric" : {
            "score" : 153.94033168599998,
            "scoreError" : "NaN",
            "scoreConfidence" : [
                "NaN",
                "NaN"
            ],
            "scorePercentiles" : {
                "0.0" : 153.290499628,
                "50.0" : 153.94033168599998,
                "90.0" : 154.590163744,
                "95.0" : 154.590163744,
                "99.0" : 154.590163744,
                "99.9" : 154.590163744,
                "99.99" : 154.590163744,
                "99.999" : 154.590163744,
                "99.9999" : 154.590163744,
                "100.0" : 154.590163744
            },
            "scoreUnit" : "s/op",
            "rawData" : [
                [
                    154.590163744,
                    153.290499628
                ]
            ]
        },
        "secondaryMetrics" : {
        }
    },
    {
        "jmhVersion" : "1.37",
        "benchmark" : "org.graphframes.benchmarks.LDBCBenchmarkSuite.benchmarkSP",
        "mode" : "avgt",
        "threads" : 1,
        "forks" : 1,
        "jdkVersion" : "17.0.11",
        "vmName" : "OpenJDK 64-Bit Server VM",
        "vmVersion" : "17.0.11+9-LTS",
        "warmupIterations" : 1,
        "warmupTime" : "10 s",
        "warmupBatchSize" : 1,
        "measurementIterations" : 2,
        "measurementTime" : "10 s",
        "measurementBatchSize" : 1,
        "primaryMetric" : {
            "score" : 156.502175388,
            "scoreError" : "NaN",
            "scoreConfidence" : [
                "NaN",
                "NaN"
            ],
            "scorePercentiles" : {
                "0.0" : 154.834303863,
                "50.0" : 156.502175388,
                "90.0" : 158.170046913,
                "95.0" : 158.170046913,
                "99.0" : 158.170046913,
                "99.9" : 158.170046913,
                "99.99" : 158.170046913,
                "99.999" : 158.170046913,
                "99.9999" : 158.170046913,
                "100.0" : 158.170046913
            },
            "scoreUnit" : "s/op",
            "rawData" : [
                [
                    154.834303863,
                    158.170046913
                ]
            ]
        },
        "secondaryMetrics" : {
        }
    }
]
```

P.P.S. I'm running benchmarks with `useLocalCheckpoints`