### PR TITLE
feat: performance improvement in GraphX CDLP

### DIFF
--- a/core/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
+++ b/core/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
@@ -117,10 +117,6 @@ class TestLDBCCases extends SparkFunSuite with GraphFrameTestSparkContext {
 
   Seq("graphx", "graphframes").foreach { algo =>
     test(s"test undirected CDLP with LDBC for algo ${algo}") {
-      // I have no idea how to write it so it will work
-      if (scala.util.Properties.versionNumberString.startsWith("2.12") && algo == "graphx") {
-        cancel("CDLP implementations are broken in 2.12, see #571")
-      }
       val testCase = ldbcTestCDLPUndirected
       val cdlpResults = testCase._1.labelPropagation.setAlgorithm(algo).maxIter(testCase._3).run()
       assert(cdlpResults.count() == testCase._1.vertices.count())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Instead of merging mutable maps on each reduce step (that leads to the complexity $O(n^2)$ ) we can just concatenate vectors ( $O(n)$ overall) and do a groupby once ( $O(n)$ ). Memory usage will also decreased, because on the first iteration of the current implementation we have `Map(vertex -> 1L)` for all the vertices, but with a new implementation the peak memory usage is `Vector` of all vertices. Concatenations of vectors is (almost) constant, vectors required 5x less memory for the same amount of elements inside compared to Maps. And there is no need to create mutable Map on each step, concatenate all the keys and iterate ( $O(2n)$ ). On my tests it is 70x performance boost and less memory consumption (see #360)

### Why are the changes needed?
Potentially resolve #360 
