### PR TITLE
hotfix: java 8 did not have Path.of

### DIFF
--- a/core/src/main/scala/org/graphframes/examples/ConnectedComponentsLDBC.scala
+++ b/core/src/main/scala/org/graphframes/examples/ConnectedComponentsLDBC.scala
@@ -9,14 +9,13 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.storage.StorageLevel
 import org.graphframes.GraphFrame
 
-import java.nio.file.Files
-import java.nio.file.Path
+import java.nio.file._
 import java.util.Properties
 
 object ConnectedComponentsLDBC {
   def main(args: Array[String]): Unit = {
     val benchmarkGraphName = args.headOption.getOrElse("kgs")
-    val resourcesPath = Path.of(args.lift(1).getOrElse("/tmp/ldbc_graphalitics_datesets"))
+    val resourcesPath = Paths.get(args.lift(1).getOrElse("/tmp/ldbc_graphalitics_datesets"))
     val caseRoot: Path = resourcesPath.resolve(benchmarkGraphName)
 
     val sparkConf = new SparkConf()

--- a/core/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
+++ b/core/src/test/scala/org/graphframes/ldbc/TestLDBCCases.scala
@@ -20,7 +20,7 @@ import java.nio.file._
 import java.util.Properties
 
 class TestLDBCCases extends SparkFunSuite with GraphFrameTestSparkContext {
-  private val resourcesPath = Path.of(new File("target").toURI)
+  private val resourcesPath = Paths.get(new File("target").toURI)
   private val unreachableID = 9223372036854775807L
 
   private def readUndirectedUnweighted(pathPrefix: String): GraphFrame = {


### PR DESCRIPTION

### What changes were proposed in this pull request?
.

### Why are the changes needed?
Spark 3.5.x may fail if the Java version is 8. That happens in our build process.
https://github.com/graphframes/graphframes/actions/runs/17837685904/job/50718930629
