### PR TITLE
feat: add bidirectional motif pattern 

### DIFF
--- a/core/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/core/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -76,7 +76,7 @@ private[graphframes] object PatternParser extends RegexParsers {
 private[graphframes] object Pattern {
   def parse(s: String): Seq[Pattern] = {
     import PatternParser._
-    val rewrittenStr: String = rewriteIncommingEdges(s)
+    val rewrittenStr: String = rewriteIncomingEdges(s)
     val result = parseAll(patterns, rewrittenStr) match {
       case result: Success[_] =>
         result.asInstanceOf[Success[Seq[Pattern]]].get
@@ -91,7 +91,7 @@ private[graphframes] object Pattern {
   /**
    * Rewirte a motif string if there are incomming edges
    */
-  private[graphframes] def rewriteIncommingEdges(patterns: String): String = {
+  private[graphframes] def rewriteIncomingEdges(patterns: String): String = {
     val reversedEdge =
       """(!*)\(([a-zA-Z0-9_]*)\)<-\[([a-zA-Z0-9_.*]*)\]-\(([a-zA-Z0-9_]*)\)""".r
     val bidirectionalEdge =

--- a/core/src/test/scala/org/graphframes/pattern/PatternSuite.scala
+++ b/core/src/test/scala/org/graphframes/pattern/PatternSuite.scala
@@ -85,16 +85,16 @@ class PatternSuite extends SparkFunSuite {
   }
 
   test("rewrite incomming edges") {
-    assert(Pattern.rewriteIncommingEdges("(u)<-[e]-(v);") === "(v)-[e]->(u)")
-    assert(Pattern.rewriteIncommingEdges("!(u)<-[e]-(v);") === "!(v)-[e]->(u)")
+    assert(Pattern.rewriteIncomingEdges("(u)<-[e]-(v);") === "(v)-[e]->(u)")
+    assert(Pattern.rewriteIncomingEdges("!(u)<-[e]-(v);") === "!(v)-[e]->(u)")
     assert(
-      Pattern.rewriteIncommingEdges("(u)<-[]-(v);(u)-[e]->(v)") === "(v)-[]->(u);(u)-[e]->(v)")
-    assert(Pattern.rewriteIncommingEdges("(u)<-[]->(v)") === "(u)-[]->(v);(v)-[]->(u)")
-    assert(Pattern.rewriteIncommingEdges("(u)<-[e]->(v)") === "(u)-[e]->(v);(v)-[e]->(u)")
-    assert(Pattern.rewriteIncommingEdges("(u)<-[*5]-(v)") === "(v)-[*5]->(u)")
-    assert(Pattern.rewriteIncommingEdges("(u)<-[*5]->(v)") === "(u)-[*5]->(v);(v)-[*5]->(u)")
+      Pattern.rewriteIncomingEdges("(u)<-[]-(v);(u)-[e]->(v)") === "(v)-[]->(u);(u)-[e]->(v)")
+    assert(Pattern.rewriteIncomingEdges("(u)<-[]->(v)") === "(u)-[]->(v);(v)-[]->(u)")
+    assert(Pattern.rewriteIncomingEdges("(u)<-[e]->(v)") === "(u)-[e]->(v);(v)-[e]->(u)")
+    assert(Pattern.rewriteIncomingEdges("(u)<-[*5]-(v)") === "(v)-[*5]->(u)")
+    assert(Pattern.rewriteIncomingEdges("(u)<-[*5]->(v)") === "(u)-[*5]->(v);(v)-[*5]->(u)")
     assert(
-      Pattern.rewriteIncommingEdges(
+      Pattern.rewriteIncomingEdges(
         "(v1)<-[e*1..2]->(v2)") === "(v1)-[e*1..2]->(v2);(v2)-[e*1..2]->(v1)")
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR implements a bidirectional motif pattern as a patterns that exist in both directions.
<img width="195" height="235" alt="image" src="https://github.com/user-attachments/assets/aad744ca-eee7-48da-8f5c-ddb31518c6f0" />
```
g.find("(u)<-[]->(v)").select("u.id", "v.id")

+---+---+
| id| id|
+---+---+
|  0|  1|
|  1|  0|
+---+---+
```

### How does it work?
It rewrites the incoming pattern string before calling the `Pattern.parse` method.
For the bidirectional pattern, `(u)<-[]->(v)` is converted to `(u)-[]->(v);(v)-[]->(u)`
It also supports the reversed pattern `(u)<-[]-(v)`. It converts to the pattern `(v)-[]->(u)`

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

### Why are the changes needed?
The feature is based on issue #502. The opinion is that it confuses users without the feature.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
