### PR TITLE
[WIP] draft

### DIFF
--- a/core/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/core/src/main/scala/org/graphframes/GraphFrame.scala
@@ -373,20 +373,52 @@ class GraphFrame private (
    * @group motif
    */
   def find(pattern: String): DataFrame = {
-    val VarLengthPattern = """\((\w+)\)-\[(\w*)\*(\d*)\.\.(\d*)\]->\((\w+)\)""".r
+    val VarLengthPattern = """\((\w+)\)-\[(\w*)\*(\d*)\.\.(\d*)\]-(>?)\((\w+)\)""".r
+    val UndirectedPattern = """\((\w+)\)-\[(\w*)\]-\((\w+)\)""".r
+
     pattern match {
-      case VarLengthPattern(src, name, min, max, dst) =>
+      case VarLengthPattern(src, name, min, max, direction, dst) =>
         if (min.isEmpty || max.isEmpty) {
           throw new InvalidParseException(
             s"Unbounded length patten ${pattern} is not supported! " +
               "Please a pattern of defined length.")
         }
-        val strToSeq: Seq[String] = (min.toInt to max.toInt).reverse.map { hop =>
-          s"($src)-[$name*$hop]->($dst)"
+        val strToSeq: Seq[(Int, String)] = (min.toInt to max.toInt).reverse.map { hop =>
+          (hop, s"($src)-[$name*$hop]->($dst)")
         }
-        strToSeq
-          .map(findAugmentedPatterns)
-          .reduce((a, b) => a.unionByName(b, allowMissingColumns = true))
+        val strToSeqReverse: Seq[(Int, String)] = if (direction.isEmpty) {
+          (min.toInt to max.toInt).reverse.map(hop => (hop, s"($src)<-[$name*$hop]-($dst)"))
+        } else {
+          Seq.empty[(Int, String)]
+        }
+
+        val out: Seq[DataFrame] = strToSeq.map { case (hop, patternStr) =>
+          findAugmentedPatterns(patternStr)
+            .withColumn("_hop", lit(hop))
+            .withColumn("_pattern", lit(patternStr))
+            .withColumn("_direction", lit("out"))
+        }
+
+        val in: Seq[DataFrame] = strToSeqReverse.map { case (hop, patternStr) =>
+          findAugmentedPatterns(patternStr)
+            .withColumn("_hop", lit(hop))
+            .withColumn("_pattern", lit(patternStr))
+            .withColumn("_direction", lit("in"))
+        }
+
+        val ret = (out ++ in).reduce((a, b) => a.unionByName(b, allowMissingColumns = true))
+        ret.orderBy("_hop", "_direction")
+
+      case UndirectedPattern(src, name, dst) =>
+        val out: DataFrame = findAugmentedPatterns(s"($src)-[$name]->($dst)")
+          .withColumn("_pattern", lit(s"($src)-[$name]->($dst)"))
+          .withColumn("_direction", lit("out"))
+        val in: DataFrame = findAugmentedPatterns(s"($src)<-[$name]-($dst)")
+          .withColumn("_pattern", lit(s"($src)<-[$name]-($dst)"))
+          .withColumn("_direction", lit("in"))
+
+        out.unionByName(in)
+
       case _ =>
         findAugmentedPatterns(pattern)
     }

--- a/core/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/core/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -50,7 +50,8 @@ private[graphframes] object PatternParser extends RegexParsers {
       case src ~ "-" ~ "[" ~ name ~ "*" ~ num ~ "]" ~ "->" ~ dst => {
         val hop: Int = num.toInt
         if (hop == 1) {
-          List(if (name.isEmpty) AnonymousEdge(src, dst) else NamedEdge(name, src, dst))
+          List(
+            if (name.isEmpty) AnonymousEdge(src, dst) else NamedEdge(s"_$name" + "1", src, dst))
         } else if (hop > 1) {
           val midVertices = (1 until hop).map(i => NamedVertex(s"_v$i"))
           val vertices = src +: midVertices :+ dst


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR improves the formatting for the variable-length and undirectional motif pattern. The two patterns are implemented in a repetitive union method from Spark dataframe.  The original patterns are actually from several patterns, the informative columns with the _ such as `_hop`, `_pattern`, `_direction` to help understand the results. 

<img width="390" height="470" alt="image" src="https://github.com/user-attachments/assets/b29ed3a1-cddd-45c2-ba6e-613ed4e6429c" />

```
g.find("(u)-[e]-(v)").where("u.id == 0")
    
+---------+---------------+---------+------------+----------+
|        u|              e|        v|    _pattern|_direction|
+---------+---------------+---------+------------+----------+
|{0, a, f}| {0, 1, friend}|{1, b, m}|(u)-[e]->(v)|       out|
|{0, a, f}| {1, 0, follow}|{1, b, m}|(u)<-[e]-(v)|        in|
|{0, a, f}|{2, 0, unknown}|{2, c, m}|(u)<-[e]-(v)|        in|
+---------+---------------+---------+------------+----------+
```

```
g.find("(v)-[e*1..3]->(u)").where("u.id == 2")

+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
|        v|            _e1|      _v1|           _e2|      _v2|           _e3|        u|_hop|      _pattern|_direction|
+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
|{1, b, m}| {1, 2, friend}|     NULL|          NULL|     NULL|          NULL|{2, c, m}|   1|(v)-[e*1]->(u)|       out|
|{0, a, f}| {0, 1, friend}|{1, b, m}|{1, 2, friend}|     NULL|          NULL|{2, c, m}|   2|(v)-[e*2]->(u)|       out|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|   3|(v)-[e*3]->(u)|       out|
|{1, b, m}| {1, 0, follow}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|   3|(v)-[e*3]->(u)|       out|
+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
```

```
g.find("(v)-[*1..3]-(u)") .where("u.id == 2")
+---------+---------+---------+---------+----+-------------+----------+
|        v|      _v1|      _v2|        u|_hop|     _pattern|_direction|
+---------+---------+---------+---------+----+-------------+----------+
|{3, d, f}|     NULL|     NULL|{2, c, m}|   1|(v)<-[*1]-(u)|        in|
|{0, a, f}|     NULL|     NULL|{2, c, m}|   1|(v)<-[*1]-(u)|        in|
|{1, b, m}|     NULL|     NULL|{2, c, m}|   1|(v)-[*1]->(u)|       out|
|{1, b, m}|{0, a, f}|     NULL|{2, c, m}|   2|(v)<-[*2]-(u)|        in|
|{0, a, f}|{1, b, m}|     NULL|{2, c, m}|   2|(v)-[*2]->(u)|       out|
|{2, c, m}|{0, a, f}|{1, b, m}|{2, c, m}|   3|(v)<-[*3]-(u)|        in|
|{0, a, f}|{0, a, f}|{1, b, m}|{2, c, m}|   3|(v)<-[*3]-(u)|        in|
|{1, b, m}|{0, a, f}|{1, b, m}|{2, c, m}|   3|(v)-[*3]->(u)|       out|
|{2, c, m}|{0, a, f}|{1, b, m}|{2, c, m}|   3|(v)-[*3]->(u)|       out|
+---------+---------+---------+---------+----+-------------+----------+
   
```

```
g.find("(v)-[e*1..3]-(u)").where("u.id == 2")
+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
|        v|            _e1|      _v1|           _e2|      _v2|           _e3|        u|_hop|      _pattern|_direction|
+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
|{3, d, f}| {2, 3, follow}|     NULL|          NULL|     NULL|          NULL|{2, c, m}|   1|(v)<-[e*1]-(u)|        in|
|{0, a, f}|{2, 0, unknown}|     NULL|          NULL|     NULL|          NULL|{2, c, m}|   1|(v)<-[e*1]-(u)|        in|
|{1, b, m}| {1, 2, friend}|     NULL|          NULL|     NULL|          NULL|{2, c, m}|   1|(v)-[e*1]->(u)|       out|
|{1, b, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|     NULL|          NULL|{2, c, m}|   2|(v)<-[e*2]-(u)|        in|
|{0, a, f}| {0, 1, friend}|{1, b, m}|{1, 2, friend}|     NULL|          NULL|{2, c, m}|   2|(v)-[e*2]->(u)|       out|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|   3|(v)<-[e*3]-(u)|        in|
|{0, a, f}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 0, follow}|{2, c, m}|   3|(v)<-[e*3]-(u)|        in|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|   3|(v)-[e*3]->(u)|       out|
|{1, b, m}| {1, 0, follow}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|   3|(v)-[e*3]->(u)|       out|
+---------+---------------+---------+--------------+---------+--------------+---------+----+--------------+----------+
```

### Why are the changes needed?
The end users may find it a bug or may not understand the results. For example, for the variable length patten with the named edge, the last column `e` is not necessary, it should be named `_e1`.

```
val df2 = g
      .find("(v)-[e*1..3]->(u)")
      .where("u.id == 2")

+---------+---------------+---------+--------------+---------+--------------+---------+---------------+
|        u|            _e1|      _v1|           _e2|      _v2|           _e3|        v|              e|
+---------+---------------+---------+--------------+---------+--------------+---------+---------------+
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|           NULL|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 0, follow}|{0, a, f}|           NULL|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|     NULL|          NULL|{1, b, m}|           NULL|
|{2, c, m}|           NULL|     NULL|          NULL|     NULL|          NULL|{3, d, f}| {2, 3, follow}|
|{2, c, m}|           NULL|     NULL|          NULL|     NULL|          NULL|{0, a, f}|{2, 0, unknown}|
|{2, c, m}| {1, 0, follow}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{1, b, m}|           NULL|
|{2, c, m}|{2, 0, unknown}|{0, a, f}|{0, 1, friend}|{1, b, m}|{1, 2, friend}|{2, c, m}|           NULL|
|{2, c, m}| {0, 1, friend}|{1, b, m}|{1, 2, friend}|     NULL|          NULL|{0, a, f}|           NULL|
|{2, c, m}|           NULL|     NULL|          NULL|     NULL|          NULL|{1, b, m}| {1, 2, friend}|
+---------+---------------+---------+--------------+---------+--------------+---------+---------------+
```

