### PR TITLE
bug: prevent negated bidirectional edge

### DIFF
--- a/core/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/core/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -100,10 +100,14 @@ private[graphframes] object Pattern {
         case reversedEdge(negation, dst, edge, src) =>
           s"$negation($src)-[$edge]->($dst)"
         case bidirectionalEdge(negation, src, edge, dst) =>
+          if (!negation.isEmpty) {
+            throw new InvalidParseException(
+              s"Motif finding does not support negated bidirectional edge: '$pattern'.")
+          }
           if (edge.isEmpty || edge.contains("*")) {
-            s"$negation($src)-[$edge]->($dst);($dst)-[$edge]->($src)"
+            s"($src)-[$edge]->($dst);($dst)-[$edge]->($src)"
           } else {
-            s"$negation($src)-[${edge}1]->($dst);($dst)-[${edge}2]->($src)"
+            s"($src)-[${edge}1]->($dst);($dst)-[${edge}2]->($src)"
           }
         case original => original
       }

--- a/core/src/test/scala/org/graphframes/pattern/PatternSuite.scala
+++ b/core/src/test/scala/org/graphframes/pattern/PatternSuite.scala
@@ -187,6 +187,11 @@ class PatternSuite extends SparkFunSuite {
         Pattern.parse("(a)-[e]->(b); ()-[e]->()")
       }
     }
+    withClue("Failed to catch parse error with not support negated bidirectional edge") {
+      intercept[InvalidParseException] {
+        Pattern.parse("!(u)<-[]->(v)")
+      }
+    }
   }
 
   test("unsupported parse on the fixed length patterns") {

--- a/docs/src/04-user-guide/04-motif-finding.md
+++ b/docs/src/04-user-guide/04-motif-finding.md
@@ -45,7 +45,7 @@ Restrictions:
 
 * Motifs are not allowed to contain edges without any named elements: `"()-[]->()"` and `"!()-[]->()"` are prohibited terms.
 * Motifs are not allowed to contain named edges within negated terms (since these named edges would never appear within results).  E.g., `"!(a)-[ab]->(b)"` is invalid, but `"!(a)-[]->(b)"` is valid.
-* Negation is not supported for the variable-length pattern and undirected pattern: `"!(a)-[*1..3]->(b)"` and `"!(a)-[]-(b)"` are not allowed.
+* Negation is not supported for the variable-length pattern, bidirectional pattern and undirected pattern: `"!(a)-[*1..3]->(b)"`, `"!(a)<-[]->(b)"` and `"!(a)-[]-(b)"` are not allowed.
 * Unbounded length patten is not supported: `"(a)-[*..3]->(b)"` and `"(a)-[*1..]->(b)"` are not allowed.
 * You cannot join additional edges with the variable length pattern: `"(a)-[*1..3]-(b);(b)-[]-(c)"`is not valid.
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
This PR ensures that a negated bidirectional edge `!(u)<-[]->(v)` is not supported. It includes the parse exception handling and documentation. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

### Why are the changes needed?
The existing code converts the bidirectional motif pattern `!(u)<-[]->(v)` to `!(u)-[]->(v);(v)-[]->(u)` which is wrong.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
