### PR TITLE
Fix: Throw IllegalArgumentException for null IDs/Src/Dst in toGraphX (Fixes #765)

### DIFF
--- a/core/src/test/scala/org/graphframes/GraphFrameSuite.scala
+++ b/core/src/test/scala/org/graphframes/GraphFrameSuite.scala
@@ -623,10 +623,12 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     val g = GraphFrame(vertices, edges)
 
-    val e = intercept[IllegalArgumentException] {
-      g.toGraphX
+    val e = intercept[org.apache.spark.SparkException] {
+      // Trigger an action to hit the lazy exception in the .map
+      g.toGraphX.vertices.collect()
     }
 
+    assert(e.getCause.isInstanceOf[IllegalArgumentException])
     assert(e.getMessage.contains("Vertex ID cannot be null"))
   }
 
@@ -645,10 +647,12 @@ class GraphFrameSuite extends SparkFunSuite with GraphFrameTestSparkContext {
 
     val g = GraphFrame(vertices, edges)
 
-    val e = intercept[IllegalArgumentException] {
-      g.toGraphX
+    val e = intercept[org.apache.spark.SparkException] {
+      // Trigger action on edges
+      g.toGraphX.edges.collect()
     }
 
+    assert(e.getCause.isInstanceOf[IllegalArgumentException])
     assert(e.getMessage.contains("Edge"))
     assert(e.getMessage.contains("cannot be null"))
   }


### PR DESCRIPTION
…(for #765)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
1) Updated the pattern matching logic in toGraphX (for both vertices and edges) to explicitly catch null values.
2) Replaced the generic GraphFramesUnreachableException with a meaningful IllegalArgumentException when null IDs are encountered.

Added Two TCs :

1) toGraphX should throw IllegalArgumentException for null IDs
2) toGraphX should throw IllegalArgumentException for null Edge Src/Dst

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixes #765
Currently, if a GraphFrame contains null values in the ID (or src/dst) columns and toGraphX is called, the pattern matching falls, throwing a GraphFramesUnreachableException without proper exception.
