### PR TITLE
doc: add Maven Central coordinates section to installation guide

### DIFF
--- a/docs/mdoc/01-installation.md
+++ b/docs/mdoc/01-installation.md
@@ -2,6 +2,31 @@
 
 If you are new to using Apache Spark, refer to the [Apache Spark Documentation](http://spark.apache.org/docs/latest/index.html) and its [Quick-Start Guide](http://spark.apache.org/docs/latest/quick-start.html) for more information.
 
+## Maven Central Coordinates
+
+GraphFrames core is [published](https://central.sonatype.com/namespace/io.graphframes) in the Maven Central under namespace `io.graphframes`. All the artifacts are groupped using the following logic.
+
+```
+graphframes-{component-name}-{spark-major-version}_{scala-version}
+```
+
+Examples:
+- `graphframes-spark3_2.12`, graphframes core for spark 3.x and scala version 2.12
+- `graphframes-graphx-spark4_2.13`, graphframes internal fork of GraphX for spark 4.x and scala version 2.13
+- `graphframes-connect-spark3_2.13`, graphframes Spark Connect plugin for spark 3.x and scala version 2.13
+
+### Core
+
+GraphFrames core is the main package that should be used.
+
+### Spark-Connect plugin
+
+Only for users who want to use GraphFrames with Spark Connect.
+
+### GraphFrames-GraphX
+
+Runtime dependency of graphframes, should be resolved automatically. Contains internal modified and updated fork of the Apache Saprk GraphX.
+
 ## Spark Versions Compatibility
 
 | Component           | Spark 3.x (Scala 2.12) | Spark 3.x (Scala 2.13) | Spark 4.x (Scala 2.13) |


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?

This commit enhances the installation documentation by adding a detailed section on Maven Central coordinates for GraphFrames. The update provides clarity on the artifact naming convention, which follows the pattern:

`graphframes-{component-name}-{spark-major-version}_{scala-version}`

The section includes specific examples for core, GraphX, and Spark Connect components, helping users correctly identify and include dependencies. It also explains the purpose of each component, distinguishing between primary usage, Spark Connect plugin, and internal GraphX dependency.

This addition ensures that users can easily locate and integrate GraphFrames artifacts for their specific Spark and Scala versions, improving the setup experience and reducing potential confusion.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

### Why are the changes needed?
Close #762 