### PR TITLE
fix: allow undirected fixed length pattern

### DIFF
--- a/core/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/core/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -790,6 +790,14 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(res.except(expected).isEmpty && expected.except(res).isEmpty)
   }
 
+  test("undirected fixed-length pattern") {
+    val res = g.find("(u)-[e*3]-(v)")
+    val expected = g.find("(u)-[e*3..3]-(v)")
+
+    assert(res.schema === expected.schema)
+    assert(res.except(expected).isEmpty && expected.except(res).isEmpty)
+  }
+
   test("stateful predicates via UDFs") {
     val chain4 = g
       .find("(a)-[ab]->(b); (b)-[bc]->(c); (c)-[cd]->(d)")


### PR DESCRIPTION
### What changes were proposed in this pull request?
It aims to support undirected fixed length pattern `(u)-[*2]-(v)`. 

### Why are the changes needed?
The pattern fails, which is unexpected.

```
$ spark-shell --packages io.graphframes:graphframes-spark4_2.13:0.10.0
scala> import org.graphframes.{examples,GraphFrame}
import org.graphframes.{examples, GraphFrame}

scala> val g: GraphFrame = examples.Graphs.friends
val g: org.graphframes.GraphFrame = GraphFrame(v:[id: string, name: string ... 1 more field], e:[src: string, dst: string ... 1 more field])

scala> g.find("(u)-[e*2]-(v)").show()
org.graphframes.InvalidParseException: Failed to parse bad motif string: '(u)-[e*2]-(v)'.  Returned message: '->' expected but '-' found
  at org.graphframes.pattern.Pattern$.parse(patterns.scala:83)
  at org.graphframes.GraphFrame.findAugmentedPatterns(GraphFrame.scala:520)
  at org.graphframes.GraphFrame.find(GraphFrame.scala:515)
  ... 42 elided
```


It may not easy to come up with a workaround by end users. It is to rewrite the pattern manually, `(u)-[*2..2]-(v)`.

### What changes were proposed in this pull request?
It implements exactly the way of workaround by adding the another pattern to the `find` method directly.

It does not yet cover undirected fixed-length chaining patterns such as `(u)-[*2]-(v); (v)-[]->(k)`, but I am opening this PR as a quick fix in case someone needs it.