### PR TITLE
fix: anonymous vertex suppot for variable length pattern

### DIFF
--- a/core/src/main/scala/org/graphframes/GraphFrame.scala
+++ b/core/src/main/scala/org/graphframes/GraphFrame.scala
@@ -469,8 +469,8 @@ class GraphFrame private (
    * @group motif
    */
   def find(pattern: String): DataFrame = {
-    val VarLengthPattern = """\((\w+)\)-\[(\w*)\*(\d*)\.\.(\d*)\]-(>?)\((\w+)\)""".r
-    val FixedLengthUndirectedPattern = """\((\w+)\)-\[(\w*)\*(\d*)\]-\((\w+)\)""".r
+    val VarLengthPattern = """\((\w*)\)-\[(\w*)\*(\d*)\.\.(\d*)\]-(>?)\((\w*)\)""".r
+    val FixedLengthUndirectedPattern = """\((\w*)\)-\[(\w*)\*(\d*)\]-\((\w*)\)""".r
 
     pattern match {
       case VarLengthPattern(src, name, min, max, direction, dst) =>
@@ -537,7 +537,9 @@ class GraphFrame private (
     val augmentedPatterns = extraPositivePatterns ++ patterns
     val df = findSimple(augmentedPatterns)
 
-    val names = Pattern.findNamedElementsInOrder(patterns, includeEdges = true)
+    val names = Pattern
+      .findNamedElementsInOrder(patterns, includeEdges = true)
+      .filter(x => !x.startsWith("__tmpv"))
     if (names.isEmpty) df else df.select(quote(names.head), names.tail.map(quote): _*)
   }
 

--- a/core/src/main/scala/org/graphframes/pattern/patterns.scala
+++ b/core/src/main/scala/org/graphframes/pattern/patterns.scala
@@ -107,7 +107,9 @@ private[graphframes] object Pattern {
         case fixedLengthPattern(negation, src, name, num, dst) =>
           val hop: Int = num.toInt
           if (hop > 0) {
-            val midVertices = (1 until hop).map(i => s"_${src}${dst}${i}")
+            val midVertices =
+              if (src.isEmpty && dst.isEmpty) (1 until hop).map(i => s"__tmpv${i}")
+              else (1 until hop).map(i => s"_${src}${dst}${i}")
             val vertices = src +: midVertices :+ dst
             vertices
               .sliding(2)

--- a/core/src/test/scala/org/graphframes/PatternMatchSuite.scala
+++ b/core/src/test/scala/org/graphframes/PatternMatchSuite.scala
@@ -798,6 +798,21 @@ class PatternMatchSuite extends SparkFunSuite with GraphFrameTestSparkContext {
     assert(res.except(expected).isEmpty && expected.except(res).isEmpty)
   }
 
+  test("undirected edge without vertex name") {
+    val res = g.find("()-[e*3]-()").drop("_pattern").collect().toSet
+    val expected =
+      g.find("(u)-[e*3]-(v)").select("_e1", "_e2", "_e3", "_hop", "_direction").collect().toSet
+
+    compareResultToExpected(res, expected)
+  }
+
+  test("directed edge name without vertex name") {
+    val res = g.find("()-[e*3]->()").collect().toSet
+    val expected = g.find("(u)-[e*3]->(v)").select("_e1", "_e2", "_e3").collect().toSet
+
+    compareResultToExpected(res, expected)
+  }
+
   test("stateful predicates via UDFs") {
     val chain4 = g
       .find("(a)-[ab]->(b); (b)-[bc]->(c); (c)-[cd]->(d)")


### PR DESCRIPTION
### What changes were proposed in this pull request?
It aims to support anonymous vertex for variable length pattern
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

### Why are the changes needed?
`()-[e*1..3]->()` fails.
`()-[e*3]-()` fails.
`()-[e*3]->()` returns results, but the intermediate vertices are still present not removed.

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
