### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala-publish.yml
+++ b/.github/workflows/scala-publish.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - "*.*.*"
 
+permissions:
+  contents: read
+
 # In the case of pushing the tag, it will publish the release.
 # In the case of pushing to the main, it will publish the SNAPSHOT
 


### PR DESCRIPTION
Potential fix for [https://github.com/graphframes/graphframes/security/code-scanning/3](https://github.com/graphframes/graphframes/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here (without changing behavior) is to define workflow-level permissions with `contents: read`, which is sufficient for checkout and aligns with CodeQL’s suggested minimal baseline.

**Where to change:** `.github/workflows/scala-publish.yml`, near the top-level keys (after `on:` block, before `jobs:`).

**What to add:**
```yml
permissions:
  contents: read
```

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
