### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,5 +1,7 @@
 name: Python CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/graphframes/graphframes/security/code-scanning/2](https://github.com/graphframes/graphframes/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/python-ci.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this CI workflow, the best minimal non-breaking setting is:

- `contents: read`

This preserves typical read-only operations like checkout while preventing unintended write access by default.

Change location:
- File: `.github/workflows/python-ci.yml`
- Insert `permissions:` after `on:` and before `jobs:`.

No imports, methods, or extra definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
