### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala-ci.yml
+++ b/.github/workflows/scala-ci.yml
@@ -1,5 +1,7 @@
 name: Scala CI
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/graphframes/graphframes/security/code-scanning/1](https://github.com/graphframes/graphframes/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the best minimal non-breaking starting point is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI operations while preventing unnecessary write scopes.

**Where to change:** `.github/workflows/scala-ci.yml`, directly after the `on:` declaration and before `jobs:`.

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
