### PR TITLE
chore: sitemap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ spark-*
 .cursor
 openspec
 .aider*
+
+# Laika
+*sitemap.xml

--- a/build.sbt
+++ b/build.sbt
@@ -226,6 +226,7 @@ lazy val benchmarks = (project in file("benchmarks"))
 lazy val buildAndCopyScalaDoc = taskKey[Unit]("Build and copy ScalaDoc to docs/api")
 lazy val buildAndCopyPythonDoc = taskKey[Unit]("Build and copy PythonDoc to docs/api")
 lazy val generateAtomFeed = taskKey[Unit]("Generate Atom feed")
+lazy val generateSitemap = taskKey[Unit]("Generate sitemap.xml for SEO")
 
 lazy val docs = (project in file("docs"))
   .dependsOn(core)
@@ -252,6 +253,8 @@ lazy val docs = (project in file("docs"))
       (core / Compile / doc).value.toPath),
     generateAtomFeed := LaikaCustoms
       .generateAtomFeed(baseDirectory.value.toPath.resolve("src/05-blog"), siteBaseUri),
+    generateSitemap := LaikaCustoms
+      .generateSitemap(baseDirectory.value.toPath.resolve("src"), siteBaseUri),
     laikaConfig := LaikaCustoms
       .laikaConfig((benchmarks / baseDirectory).value.toPath.resolve("jmh-result.json"))
       .withConfigValue(LaikaKeys.siteBaseURL, siteBaseUri)
@@ -261,8 +264,8 @@ lazy val docs = (project in file("docs"))
       .withConfigValue("scala.version", scalaVer),
     laikaExtensions := Seq(GitHubFlavor, SyntaxHighlighting, LaikaCustomDirectives),
     laikaHTML := (laikaHTML dependsOn mdoc.toTask(
-      "") dependsOn generateAtomFeed dependsOn buildAndCopyScalaDoc dependsOn buildAndCopyPythonDoc dependsOn (core / Compile / doc)).value,
+      "") dependsOn generateAtomFeed dependsOn generateSitemap dependsOn buildAndCopyScalaDoc dependsOn buildAndCopyPythonDoc dependsOn (core / Compile / doc)).value,
     laikaPreview := (laikaPreview dependsOn mdoc.toTask(
-      "") dependsOn generateAtomFeed dependsOn buildAndCopyScalaDoc dependsOn buildAndCopyPythonDoc dependsOn (core / Compile / doc)).value,
+      "") dependsOn generateAtomFeed dependsOn generateSitemap dependsOn buildAndCopyScalaDoc dependsOn buildAndCopyPythonDoc dependsOn (core / Compile / doc)).value,
     laikaTheme := LaikaCustoms.heliumTheme(version.value),
     Laika / sourceDirectories := Seq((ThisBuild / baseDirectory).value / "docs" / "src"))

--- a/project/LaikaCustoms.scala
+++ b/project/LaikaCustoms.scala
@@ -13,7 +13,9 @@ import laika.theme.ThemeProvider
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import scala.util.Try
@@ -120,6 +122,55 @@ object LaikaCustoms {
     val feedContent = header + collected._1.append("\n\t</channel>\n</rss>").mkString
     val feedFile = blogDir.resolve("feed.xml")
     Files.write(feedFile, feedContent.getBytes)
+  }
+
+  /**
+   * Generate a sitemap.xml from the Laika source markdown files.
+   *
+   * Each .md file maps 1:1 to an .html URL. The lastmod timestamp is taken from
+   * the .md file's last-modified time so that it reflects the actual content age
+   * rather than the build timestamp.
+   *
+   * The resulting sitemap.xml is written into the docs source directory so that
+   * Laika copies it through to the generated site as a static file.
+   */
+  def generateSitemap(sourceDir: Path, baseUrl: String): Unit = {
+    val mdFiles = Files
+      .walk(sourceDir)
+      .iterator()
+      .asScala
+      .filter(_.getFileName.toString.endsWith(".md"))
+      .toSeq
+      .sortBy(_.toString)
+
+    val w3cFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneId.of("UTC"))
+
+    val entries = mdFiles.map { mdFile =>
+      val relative = sourceDir.relativize(mdFile).toString.replaceAll("\\.md$", ".html")
+      val loc = s"$baseUrl/$relative"
+      val lastModified = Files.getLastModifiedTime(mdFile)
+      val lastmod = w3cFormatter.format(Instant.ofEpochMilli(lastModified.toMillis))
+      println(s"Generating sitemap entry for $loc (lastmod=$lastmod)")
+      s"""<url>
+         |  <loc>$loc</loc>
+         |  <lastmod>$lastmod</lastmod>
+         |</url>""".stripMargin
+    }
+
+    val sitemap = new StringBuilder()
+    sitemap.append("""<?xml version="1.0" encoding="UTF-8"?>""")
+    sitemap.append("\n")
+    sitemap.append("""<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""")
+    sitemap.append("\n")
+    entries.foreach { entry =>
+      sitemap.append(entry)
+      sitemap.append("\n")
+    }
+    sitemap.append("</urlset>")
+
+    val sitemapFile = sourceDir.resolve("sitemap.xml")
+    Files.write(sitemapFile, sitemap.mkString.getBytes)
+    println(s"Sitemap written to $sitemapFile with ${entries.size} entries")
   }
 
   def laikaConfig(benchmarksFile: Path): LaikaConfig = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Simple `sitemap.xml` generator for the better SEO visibility.

I tested it locally, looks fine for me.

<img width="674" height="769" alt="image" src="https://github.com/user-attachments/assets/e92eeab1-bc08-4ed3-889b-ff99e231437a" />

<img width="688" height="756" alt="image" src="https://github.com/user-attachments/assets/7bbf64a5-f263-4f5b-bcdc-0fb5ccb6d904" />

### Why are the changes needed?
Close #851 

### Details
LastMod time is inferred from the last mod time of the `*.md` files and looks like it is working fine. Mapping of md-files to html-files is one2one in `Laika`.