### PR TITLE
docs: explain checkpointing before GraphFrame creation

### DIFF
--- a/docs/src/04-user-guide/13-configurations.md
+++ b/docs/src/04-user-guide/13-configurations.md
@@ -15,6 +15,82 @@ The following table lists all available GraphFrames configurations:
 | `spark.graphframes.connectedComponents.checkpointinterval` | Sets checkpoint interval in terms of number of iterations. Checkpointing regularly helps recover from failures, clean shuffle files, shorten the lineage of the computation graph, and reduce the complexity of plan optimization. As of Spark 2.0, the complexity of plan optimization would grow exponentially without checkpointing. Hence, disabling or setting longer-than-default checkpoint intervals are not recommended. Checkpoint data is saved under `org.apache.spark.SparkContext.getCheckpointDir` with prefix "connected-components". If the checkpoint directory is not set, this throws a `java.io.IOException`. Set a nonpositive value to disable checkpointing. This parameter is only used when the algorithm is set to "graphframes". | Optional (default: `2`) | 0.9.0 |
 | `spark.graphframes.connectedComponents.intermediatestoragelevel` | Sets storage level for intermediate datasets that require multiple passes. | Optional (default: `MEMORY_AND_DISK`) | 0.9.0 |
 
+## Managing DataFrame Lineage Before GraphFrame Creation
+
+Spark keeps the transformation history (the *lineage*) of each DataFrame in
+its logical plan. A long or highly branched plan can make analysis and query
+optimization increasingly expensive. This often appears when `vertices` or
+`edges` have been assembled through many joins, unions, filters, or projections
+before they are passed to `GraphFrame`.
+
+Checkpoint the prepared DataFrames at a stable boundary before constructing the
+graph. The checkpoint must preserve the required graph columns: `vertices`
+must contain `id`, and `edges` must contain `src` and `dst`.
+
+### Scala API
+
+```scala
+import org.apache.spark.sql.SparkSession
+import org.graphframes.GraphFrame
+
+val spark = SparkSession.builder().getOrCreate()
+
+// Persistent checkpoints are recoverable if an executor is lost.
+spark.sparkContext.setCheckpointDir("/path/to/spark-checkpoints")
+
+val preparedVertices = rawVertices
+  .filter("active = true")
+  .select("id", "name")
+  .checkpoint(eager = true)
+
+val preparedEdges = rawEdges
+  .filter("weight > 0")
+  .select("src", "dst", "weight")
+  .checkpoint(eager = true)
+
+val graph = GraphFrame(preparedVertices, preparedEdges)
+```
+
+`checkpoint(eager = true)` materializes the files immediately and truncates the
+lineage that precedes the checkpoint. Set the checkpoint directory before
+materializing either DataFrame. If the workload can tolerate recomputation
+after executor loss, `localCheckpoint(eager = true)` avoids the checkpoint
+directory and is usually faster, but local checkpoint data is not reliable and
+should not be used as a recovery boundary.
+
+### Python API
+
+```python
+from graphframes import GraphFrame
+
+# Persistent checkpoints are recoverable if an executor is lost.
+spark.sparkContext.setCheckpointDir("/path/to/spark-checkpoints")
+
+prepared_vertices = (
+    raw_vertices.filter("active = true")
+    .select("id", "name")
+    .checkpoint(eager=True)
+)
+
+prepared_edges = (
+    raw_edges.filter("weight > 0")
+    .select("src", "dst", "weight")
+    .checkpoint(eager=True)
+)
+
+graph = GraphFrame(prepared_vertices, prepared_edges)
+```
+
+Use `localCheckpoint(eager=True)` instead when losing executor-local data is
+acceptable. The `spark.graphframes.useLocalCheckpoints` setting controls local
+checkpointing used by supported GraphFrames algorithms; it does not replace
+checkpointing complex input DataFrames before `GraphFrame` construction.
+
+Checkpointing is a deliberate materialization boundary, so use it after a
+meaningful preparation stage rather than after every transformation. It can
+add I/O and storage overhead, but avoids repeatedly analyzing an unnecessarily
+large plan when the graph is created or queried.
+
 ## Setting Configurations
 
 GraphFrames configurations can be set in several ways:


### PR DESCRIPTION
## Summary

- document why complex DataFrame lineage can make GraphFrame construction and query planning expensive
- show persistent checkpointing before graph creation in Scala and Python
- explain when local checkpoints are appropriate and clarify that GraphFrames algorithm settings do not checkpoint input DataFrames automatically

## Guidance added

The new section preserves the required `id`, `src`, and `dst` graph columns, materializes both inputs with `checkpoint(eager = true)`, and explains the reliability and storage trade-offs of `localCheckpoint`.

## Validation

- `git diff --check`
- Markdown code-fence balance checked (16 fence markers)
- The repository `build/sbt docs/mdoc` task could not run in this Windows checkout: the wrapper requires a downloadable sbt 1.11.0 launcher, and the download was unavailable. No source or build artifacts were left staged.

Fixes #746
