### PR TITLE
fix: resolve AttributeError in pageRank on Spark Connect (issue #889)

### DIFF
--- a/python/graphframes/connect/graphframes_client.py
+++ b/python/graphframes/connect/graphframes_client.py
@@ -352,6 +352,12 @@ class GraphFrameConnect:
     def pregel(self):
         return PregelConnect(self)
 
+    @property
+    def outDegrees(self) -> DataFrame:
+        return self._edges.groupBy(F.col(self._SRC).alias(self._ID)).agg(
+            F.count("*").alias("outDegree")
+        )
+
     def find(self, pattern: str) -> DataFrame:
         @final
         class Find(LogicalPlan):
@@ -913,7 +919,7 @@ class GraphFrameConnect:
         )
 
     def _update_page_rank_edge_weights(self, new_vertices: DataFrame) -> "GraphFrameConnect":
-        cols2select = self.edges.columns + ["weight"]
+        cols2select = self._edges.columns + ["weight"]
         new_edges = (
             self._edges.join(
                 new_vertices.withColumn(self._SRC, F.col(self._ID)),

--- a/python/tests/test_graphframes.py
+++ b/python/tests/test_graphframes.py
@@ -457,6 +457,32 @@ def test_page_rank(spark: SparkSession, args: PregelArguments) -> None:
     _ = ranks.unpersist()
 
 
+def test_graphframes_pagerank(spark: SparkSession) -> None:
+    """Regression test for issue #889: pageRank fails on Spark Connect due to
+    AttributeError accessing self.edges and self.outDegrees on GraphFrameConnect."""
+    edges = spark.createDataFrame(
+        [
+            [0, 1],
+            [1, 2],
+            [2, 4],
+            [2, 0],
+            [3, 4],
+            [4, 0],
+            [4, 2],
+        ],
+        ["src", "dst"],
+    )
+    vertices = spark.createDataFrame([[0], [1], [2], [3], [4]], ["id"])
+    g = GraphFrame(vertices, edges)
+
+    result = g.pageRank(resetProbability=0.15, maxIter=3)
+
+    assert "pagerank" in result.vertices.columns
+    assert "weight" in result.edges.columns
+    assert result.vertices.count() == 5
+    assert result.edges.count() == edges.count()
+
+
 @pytest.mark.parametrize("args", PREGEL_ARGUMENTS, ids=PREGEL_IDS)
 def test_pregel_early_stopping(spark: SparkSession, args: PregelArguments) -> None:
     edges = spark.createDataFrame(


### PR DESCRIPTION
This should address issue #889. Here is the commit details:

GraphFrameConnect._update_page_rank_edge_weights referenced self.edges (no public attribute — only self._edges exists) and self.outDegrees (not defined on GraphFrameConnect), causing AttributeError when calling pageRank() via Spark Connect.

- Add outDegrees property to GraphFrameConnect
- Fix self.edges.columns → self._edges.columns

Add regression test test_graphframes_pagerank covering the pageRank API.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. Ensure you have added or run the appropriate tests for your PR
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Two fixes to `GraphFrameConnect` in `python/graphframes/connect/graphframes_client.py`:

1. **Added `outDegrees` property** — `GraphFrameConnect` was missing this property
   (present on `GraphFrame`) which is required by the `pageRank` algorithm internally.

2. **Fixed attribute reference in `_update_page_rank_edge_weights`** — changed
   `self.edges.columns` → `self._edges.columns`. `GraphFrameConnect` exposes no
   public `edges` attribute; the backing DataFrame is `self._edges`.

A regression test `test_graphframes_pagerank` is added to `python/tests/test_graphframes.py`
to cover the `pageRank()` API via Spark Connect end-to-end.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Calling `pageRank()` on a `GraphFrameConnect` instance raised `AttributeError` in two
places due to incorrect attribute references introduced when porting the algorithm to the
Connect client:

- `self.edges` → `AttributeError: 'GraphFrameConnect' object has no attribute 'edges'`
- `self.outDegrees` → `AttributeError: 'GraphFrameConnect' object has no attribute 'outDegrees'`

Both errors are surfaced immediately on any `pageRank()` call via Spark Connect, making
the feature completely unusable in Connect mode. This PR fixes both issues and adds a
test to prevent regression. Fixes #889.
