### PR TITLE
fix: point the CC benchmark row at randomized_contraction

### DIFF
--- a/dev/run_doc_benchmarks.py
+++ b/dev/run_doc_benchmarks.py
@@ -42,7 +42,7 @@ def main() -> None:
         (
             results_dir / "connected-components.json",
             "benchmarks/Jmh/run -rf json -p graphName=wiki-Talk -p useLocalCheckpoints=true "
-            "-p algorithm=randomized_contraction,graphx "
+            "-p algorithm=randomized_contraction,graphx -p broadcastThreshold=-1 "
             "org.graphframes.benchmarks.ConnectedComponentsBenchmark",
         ),
         (

--- a/docs/src/01-about/03-benchmarks.md
+++ b/docs/src/01-about/03-benchmarks.md
@@ -25,7 +25,7 @@ algorithms is measured, and the time to read/parse source files, serialize, and 
 | -------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- |
 | Shortest Paths Graphframes       | ${benchmarks.benchmarkShortestPaths.graphframes.measurements}       | ${benchmarks.benchmarkShortestPaths.graphframes.metric}       |
 | Shortest Paths GraphX            | ${benchmarks.benchmarkShortestPaths.graphx.measurements}            | ${benchmarks.benchmarkShortestPaths.graphx.metric}            |
-| Connected Components Graphframes | ${benchmarks.benchmarkConnectedComponents.graphframes.measurements} | ${benchmarks.benchmarkConnectedComponents.graphframes.metric} |
+| Connected Components (Randomized Contraction) | ${benchmarks.benchmarkConnectedComponents.randomized_contraction.measurements} | ${benchmarks.benchmarkConnectedComponents.randomized_contraction.metric} |
 | Connected Components GraphX      | ${benchmarks.benchmarkConnectedComponents.graphx.measurements}      | ${benchmarks.benchmarkConnectedComponents.graphx.metric}      |
 | Label Propagation GraphFrames    | ${benchmarks.benchmarkLabelPropagation.graphframes.measurements}    | ${benchmarks.benchmarkLabelPropagation.graphframes.metric}    |
 | Label Propagation GraphX         | ${benchmarks.benchmarkLabelPropagation.graphx.measurements}         | ${benchmarks.benchmarkLabelPropagation.graphx.metric}         |


### PR DESCRIPTION
## Problem

`Deploy Docs` has been failing since #888. The 0.12.2 docs deploy hit it:

```
/01-about/03-benchmarks.md
  [28]: Missing required reference: 'benchmarks.benchmarkConnectedComponents.graphframes.measurements'
  [28]: Missing required reference: 'benchmarks.benchmarkConnectedComponents.graphframes.metric'
```

#888 changed the connected components doc benchmark in `dev/run_doc_benchmarks.py` from `-p algorithm=graphframes,graphx` to `-p algorithm=randomized_contraction,graphx`.

`LaikaCustoms` builds benchmark config keys as `benchmarks.$benchmarkName.$algorithm.*`, taking `$algorithm` straight from the JMH `params.algorithm`. So the emitted keys became `benchmarks.benchmarkConnectedComponents.randomized_contraction.*`, while `docs/src/01-about/03-benchmarks.md` still referenced `...graphframes.*`. Laika treats a missing reference as a hard error, so `laikaHTML` aborts.

`docs.yml` is `workflow_dispatch`-only — no push or PR trigger — so nothing exercised the docs build when #888 merged. The last green run was `28d181c0` (v0.12.1, 2026-06-17).

Only the connected components row is affected. Shortest Paths and Label Propagation still run `-p algorithm=graphframes,graphx`, so their references still resolve.

## Fix

**1. Point the row at the algorithm that is actually benchmarked**, and relabel it to match. This is what unblocks the docs build.

**2. Re-pin `-p broadcastThreshold=-1`**, which #888 dropped alongside the algorithm change.

`ConnectedComponentsBenchmark` declares `@Param(Array("1000000", "-1"))` for `broadcastThreshold`, so without the pin JMH runs the full cross-product — 4 records instead of 2. Neither `randomized_contraction` (`ConnectedComponents.run` does not pass it to `RandomizedContraction.run`) nor the benchmark's `graphx` branch reads that value, so the two extra runs are duplicates. They double the docs benchmark time, and because both records fold into the same `benchmarks.benchmarkConnectedComponents.<algorithm>` key, the number that ends up published depends on which one `LaikaCustoms` folds last.

Happy to drop the second commit if you would rather keep this PR to the build fix alone.

This does not affect the published 0.12.2 artifacts on Maven Central or PyPI — those are fine. It only unblocks the docs site, which is still serving 0.12.1.

## Follow-up worth considering

`docs.yml` running only on `workflow_dispatch` means this class of breakage is invisible until someone cuts a release. Adding a build-only job (no deploy) on pull requests would have caught it at #888. Happy to open a separate PR for that if maintainers want it.
