### PR TITLE
fix: map randomized_contraction output back to non-integral vertex IDs

### DIFF
--- a/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
+++ b/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
@@ -253,6 +253,20 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
             col(ID),
             coalesce(col("new_component"), col(ID))
               .alias(ConnectedComponents.COMPONENT))
+      } else if (!inputGraph.hasIntegralIdType) {
+        // `finalReps` is keyed by the internal LongType vertex index, not by the original
+        // vertex ID, so for non-integral ID types the results have to be mapped back through
+        // `indexedVertices`. Joining `inputGraph.vertices` on ID directly would make Spark
+        // coerce the two sides to a common type, which either fails with CAST_INVALID_INPUT
+        // (ANSI mode) or silently produces wrong results.
+        // See https://github.com/graphframes/graphframes/issues/892
+        inputGraph.indexedVertices
+          .withColumnRenamed(ID, ConnectedComponents.ORIG_ID)
+          .join(finalReps, col(ID) === col(LONG_ID), "left")
+          .select(
+            col(ConnectedComponents.ORIG_ID).alias(ID),
+            coalesce(col(ConnectedComponents.COMPONENT), col(LONG_ID))
+              .alias(ConnectedComponents.COMPONENT))
       } else {
         inputGraph.vertices
           .join(finalReps, ID, "left")

--- a/core/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
+++ b/core/src/test/scala/org/graphframes/lib/ConnectedComponentsSuite.scala
@@ -97,6 +97,40 @@ class ConnectedComponentsSuite extends SparkFunSuite with GraphFrameTestSparkCon
     }
   }
 
+  Seq(true, false).foreach { useLabelsAsComponents =>
+    test(
+      "randomized contraction with non-integral IDs, " +
+        s"useLabelsAsComponents=$useLabelsAsComponents") {
+      // See https://github.com/graphframes/graphframes/issues/892 : the randomized contraction
+      // implementation works on the internal LongType vertex indices, so the results have to be
+      // mapped back onto the original (here: StringType) vertex IDs.
+      val friends = Graphs.friends
+      val components = friends.connectedComponents
+        .setAlgorithm(ConnectedComponents.ALGO_RANDOMIZED_CONTRACTION)
+        .setUseLabelsAsComponents(useLabelsAsComponents)
+        .run()
+      TestUtils.checkColumnType(components.schema, ID, DataTypes.StringType)
+      val expected = Set(Set("a", "b", "c", "d", "e", "f"), Set("g"))
+
+      if (useLabelsAsComponents) {
+        TestUtils.checkColumnType(components.schema, "component", DataTypes.StringType)
+        assertComponents(components, expected)
+      } else {
+        // Component IDs are arbitrary Longs in this mode, so only the grouping is checked.
+        TestUtils.checkColumnType(components.schema, "component", DataTypes.LongType)
+        val grouping = components
+          .select(col("component"), col(ID))
+          .collect()
+          .groupBy(_.getLong(0))
+          .values
+          .map(_.map(_.getString(1)).toSet)
+          .toSet
+        assert(grouping === expected)
+      }
+      components.unpersist()
+    }
+  }
+
   Seq(true, false).foreach(useSkewedJoin => {
     Seq(true, false).foreach(useLocalCheckpoint => {
       val testPostfixName = s"${if (useLocalCheckpoint) " with local checkpoint"


### PR DESCRIPTION
Fixes #892.

## Problem

`randomized_contraction` produces wrong results, or fails outright, on graphs whose vertex IDs are not integral — despite the user guide stating it "always produces random `Long` component IDs regardless of the input vertex ID type".

`finalReps` is keyed by the internal `LongType` vertex index assigned in `prepare()` (via `graph.indexedVertices`), **not** by the original vertex ID. The `useLabelsAsComponents = false` branch nevertheless joined `inputGraph.vertices` on `ID` and fell back to `coalesce(component, id)`. Both the join key and the coalesce mix `StringType` with `LongType`, so Spark's implicit coercion decides the outcome:

- **Spark 4 (ANSI on)** — the string side is cast to `BIGINT` and the query fails with `CAST_INVALID_INPUT`.
- **Spark 3.5 (ANSI off)** — no exception. The join silently never matches, every vertex falls through to the fallback, and `component` comes back as `StringType`. This is the more dangerous case: wrong answers, no error.

The `useLabelsAsComponents = true` path already handled this correctly, via a dedicated `!hasIntegralIdType` branch. The `false` path simply never got one.

## Fix

Add the missing branch, mirroring the existing correct one: map back through `indexedVertices`, join `LONG_ID` to `LONG_ID`, and use `LONG_ID` as the coalesce fallback for isolated vertices so both sides are `LongType`. Purely additive — no existing branch is modified, and the integral-ID path is untouched.

`GraphFrame.indexedVertices` is a `lazy val`, so `prepare()` and this branch observe the same `monotonically_increasing_id()` assignment; the index mapping is stable across both uses. The `isGraphPrepared = true` path is unaffected, since a prepared graph has integral IDs and still takes the final `else`.

## Tests

`randomized_contraction` was previously exercised only by `TestLDBCCases`, whose graphs are explicitly `LongType` — which is why this shipped. Added `ConnectedComponentsSuite` coverage over `Graphs.friends` (String IDs, with `g` isolated so the coalesce fallback is exercised) for both `useLabelsAsComponents` values, asserting component grouping and column type.

Verified locally: `testOnly *ConnectedComponentsSuite` 65 passed; full `core/test` 332 passed with 14 pre-existing Spark-version cancellations; `scalafmtCheckAll` and `scalafixAll --check` clean. Before the fix, the new `useLabelsAsComponents=false` case fails on the default 3.5.8 build with `Column component must be of type LongType but was actually StringType`.

End-to-end on Spark 4.0.1: pre-fix `CAST_INVALID_INPUT`; post-fix `struct<id:string,component:bigint>` with correct grouping and a `Long` component for the isolated vertex.

I did not run the full multi-Spark matrix from AGENTS.md locally — relying on CI for that.

## Two related issues found but deliberately not fixed here

1. **The zero-edge early return has the same class of bug.** It returns `inputGraph.vertices.select(col(ID), col(ID).alias(COMPONENT))` unconditionally, so a String-ID graph with no edges yields `component: string` (and an Int-ID graph yields `component: int`), where `two_phase` yields `bigint`. After this PR, `randomized_contraction` on a String graph returns `bigint` when edges exist and `string` when none do. Left alone because fixing it changes behaviour for integral-ID graphs too; happy to fold it in or open a follow-up.

2. **`randomized_contraction` drops all vertex attributes.** Every output branch selects only `id` and `component`, whereas `two_phase` and `graphx` also return `col("attr.*")`. This contradicts the `ConnectedComponents` scaladoc ("The resulting DataFrame contains all the vertex information and one additional column") and affects all ID types, so it is out of scope here. Same root cause for going unnoticed: the LDBC tests compare only `id` and `component`.
