### PR TITLE
fix: clean randomized contraction checkpoints on failure

### DIFF
--- a/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
+++ b/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
@@ -21,6 +21,7 @@ import java.io.IOException
 import java.util.UUID
 import scala.collection.mutable.Stack
 import scala.util.Random
+import scala.util.control.NonFatal
 
 /**
  * Implementation of parallel connected components algorithm using randomized contraction, based
@@ -88,6 +89,19 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
     var iter = 0
 
     def tableName(iter: Int): String = s"${checkpointDir}/ccreps-${iter}"
+
+    def cleanupCheckpointDir(): Unit = {
+      try {
+        val checkpointPath = new Path(checkpointDir)
+        val fs = checkpointPath.getFileSystem(sc.hadoopConfiguration)
+        if (fs.exists(checkpointPath)) {
+          val _ = fs.delete(checkpointPath, true)
+        }
+      } catch {
+        case NonFatal(e) =>
+          logWarn(s"Failed to clean up checkpoint directory $checkpointDir: ${e.getMessage}")
+      }
+    }
 
     val graph = if (isGraphPrepared) {
       inputGraph
@@ -281,16 +295,13 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
       outputComponents.count()
 
       // clean-up
-      val chDirPath = new Path(checkpointDir)
-      val fs = chDirPath.getFileSystem(sc.hadoopConfiguration)
-      if (fs.exists(chDirPath)) {
-        fs.delete(chDirPath, true)
-      }
+      cleanupCheckpointDir()
 
       outputComponents
     } finally {
       // to be 100% sure;
       edges.unpersist()
+      cleanupCheckpointDir()
       val dereg = functionRegistry.dropFunction(FunctionIdentifier("_axpb"))
       if (!dereg) {
         logWarn(

--- a/core/src/test/scala/org/graphframes/lib/RandomizedContractionSuite.scala
+++ b/core/src/test/scala/org/graphframes/lib/RandomizedContractionSuite.scala
@@ -192,6 +192,36 @@ class RandomizedContractionSuite extends SparkFunSuite with GraphFrameTestSparkC
     assertFunctionRegistryClean()
   }
 
+  test("RandomizedContraction: cleans up checkpoint files after failure") {
+    val graph = Graphs.chain(3L)
+    val checkpointRoot = new org.apache.hadoop.fs.Path(spark.sparkContext.getCheckpointDir.get)
+
+    intercept[ArithmeticException] {
+      RandomizedContraction
+        .run(
+          inputGraph = graph,
+          useLabelsAsComponents = false,
+          intermediateStorageLevel = StorageLevel.MEMORY_AND_DISK,
+          useLocalCheckpoints = true,
+          checkpointInterval = 0,
+          isGraphPrepared = false)
+        .count()
+    }
+
+    val fs = checkpointRoot.getFileSystem(spark.sparkContext.hadoopConfiguration)
+    val remainingCheckpointDirs =
+      if (fs.exists(checkpointRoot)) {
+        fs
+          .listStatus(checkpointRoot)
+          .map(_.getPath.getName)
+          .filter(_.startsWith("randomized-contraction-"))
+      } else {
+        Array.empty[String]
+      }
+    assert(remainingCheckpointDirs.isEmpty)
+    assertFunctionRegistryClean()
+  }
+
   test("RandomizedContraction: no memory leaks") {
     val priorCached = spark.sparkContext.getPersistentRDDs
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Ensure that RandomizedContraction checkpoint directories are cleaned up on both successful and failed executions.

A scoped cleanup routine is now called from the normal completion path and from finally. Cleanup failures are logged without masking the original algorithm failure.

A regression test forces a failure after intermediate parquet materialization and verifies that no randomized-contraction-* directory remains.

### Why are the changes needed?

If an intermediate Spark or filesystem operation fails, the current implementation can leave temporary checkpoint data behind. Repeated executions can therefore leak storage, especially when using remote object stores.

This addresses #894.

### Validation

- RandomizedContractionSuite on WSL with Java 11
- 14 tests passed
- 0 failed
- 0 aborted
- git diff --check passed

The change does not modify public APIs.