### PR TITLE
feat: set Spark job descriptions for iterative algorithms

### DIFF
--- a/core/src/main/scala/org/graphframes/lib/DetectingCycles.scala
+++ b/core/src/main/scala/org/graphframes/lib/DetectingCycles.scala
@@ -85,6 +85,7 @@ object DetectingCycles {
       x => array_append(x, col(GraphFrame.ID)))
 
     preparedGraph.pregel
+      .setJobDescriptionPrefix("GraphFrames DetectingCycles")
       .setCheckpointInterval(checkpointInterval)
       .setUseLocalCheckpoints(useLocalCheckpoints)
       .setIntermediateStorageLevel(intermediateStorageLevel)

--- a/core/src/main/scala/org/graphframes/lib/KCore.scala
+++ b/core/src/main/scala/org/graphframes/lib/KCore.scala
@@ -78,6 +78,7 @@ object KCore extends Serializable with Logging {
 
     try {
       val pregel = preparedGraph.pregel
+        .setJobDescriptionPrefix("GraphFrames KCore")
         .setMaxIter(Int.MaxValue)
         .setIntermediateStorageLevel(storageLevel)
         .setCheckpointInterval(checkpointInterval)

--- a/core/src/main/scala/org/graphframes/lib/LabelPropagation.scala
+++ b/core/src/main/scala/org/graphframes/lib/LabelPropagation.scala
@@ -110,6 +110,7 @@ private object LabelPropagation {
       graph.edges.select(GraphFrame.SRC, GraphFrame.DST))
 
     var pregel = preparedGraph.pregel
+      .setJobDescriptionPrefix("GraphFrames LabelPropagation")
       .withVertexColumn(LABEL_ID, col(GraphFrame.ID).alias(LABEL_ID), keyWithMaxValue(Pregel.msg))
       .setMaxIter(maxIter)
       .setStopIfAllNonActiveVertices(true)

--- a/core/src/main/scala/org/graphframes/lib/MaximalIndependentSet.scala
+++ b/core/src/main/scala/org/graphframes/lib/MaximalIndependentSet.scala
@@ -5,6 +5,7 @@ import org.apache.spark.sql.functions.*
 import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.storage.StorageLevel
 import org.graphframes.GraphFrame
+import org.graphframes.JobDescription
 import org.graphframes.Logging
 import org.graphframes.WithCheckpointInterval
 import org.graphframes.WithIntermediateStorageLevel
@@ -103,10 +104,13 @@ object MaximalIndependentSet extends Serializable with Logging {
 
     // randomized algorithms are not working with AQE well
     val originalAQE = spark.conf.get("spark.sql.adaptive.enabled")
+    val previousJobDescription =
+      spark.sparkContext.getLocalProperty(JobDescription.JOB_DESCRIPTION_KEY)
     try {
       spark.conf.set("spark.sql.adaptive.enabled", "false")
 
       while (!converged) {
+        spark.sparkContext.setJobDescription(s"GraphFrames MaximalIndependentSet: iteration $i")
         val iterSeed = rng.nextLong()
         // compute effective degree as a sum of nbrs p
         val effectiveDegrees =
@@ -210,6 +214,8 @@ object MaximalIndependentSet extends Serializable with Logging {
       vertices.unpersist(true)
       edges.unpersist(true)
 
+      spark.sparkContext.setJobDescription(
+        "GraphFrames MaximalIndependentSet: materializing final result")
       val mis = misDF.filter(col(isMIS)).select(GraphFrame.ID).persist(storageLevel)
       // materialize
       mis.count()
@@ -220,6 +226,8 @@ object MaximalIndependentSet extends Serializable with Logging {
     } finally {
       // Restore original AQE setting
       spark.conf.set("spark.sql.adaptive.enabled", originalAQE)
+      spark.sparkContext
+        .setLocalProperty(JobDescription.JOB_DESCRIPTION_KEY, previousJobDescription)
     }
   }
 }

--- a/core/src/main/scala/org/graphframes/lib/Pregel.scala
+++ b/core/src/main/scala/org/graphframes/lib/Pregel.scala
@@ -27,8 +27,10 @@ import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.graphframes.SparkShims
 import org.graphframes.GraphFrame
 import org.graphframes.GraphFrame.*
+import org.graphframes.JobDescription
 import org.graphframes.Logging
 import org.graphframes.WithIntermediateStorageLevel
+import org.graphframes.WithJobDescriptionPrefix
 import org.graphframes.WithLocalCheckpoints
 
 import java.io.IOException
@@ -93,7 +95,10 @@ import scala.util.control.Breaks.breakable
 class Pregel(val graph: GraphFrame)
     extends Logging
     with WithLocalCheckpoints
-    with WithIntermediateStorageLevel {
+    with WithIntermediateStorageLevel
+    with WithJobDescriptionPrefix {
+
+  override protected def defaultJobDescriptionPrefix: String = "GraphFrames Pregel"
 
   private val withVertexColumnList = collection.mutable.ListBuffer.empty[(String, Column, Column)]
 
@@ -410,6 +415,12 @@ class Pregel(val graph: GraphFrame)
       withVertexColumnList.size > 0,
       "There should be at least one additional vertex columns for updating.")
 
+    JobDescription.withRestoredJobDescription(graph.spark) {
+      runAlgorithm()
+    }
+  }
+
+  private def runAlgorithm(): DataFrame = {
     val sendMsgsColList = sendMsgs.toList.map { case (id, msg) =>
       struct(id.as(ID), msg.as("msg"))
     }
@@ -466,6 +477,9 @@ class Pregel(val graph: GraphFrame)
 
     var iteration = 1
 
+    // Avoid "iteration 3 / 2147483647" for algorithms that rely on early stopping.
+    val maxIterSuffix = if (maxIter == Int.MaxValue) "" else s" / $maxIter"
+
     val shouldCheckpoint = checkpointInterval > 0
 
     if (shouldCheckpoint && graph.spark.sparkContext.getCheckpointDir.isEmpty && !useLocalCheckpoints) {
@@ -490,6 +504,8 @@ class Pregel(val graph: GraphFrame)
     breakable {
       while (iteration <= maxIter) {
         logInfo(s"start Pregel iteration $iteration / $maxIter")
+        graph.spark.sparkContext.setJobDescription(
+          s"$getJobDescriptionPrefix: iteration $iteration$maxIterSuffix")
         val currRoundPersistent = scala.collection.mutable.Queue[DataFrame]()
         currRoundPersistent.enqueue(currentVertices.persist(intermediateStorageLevel))
 
@@ -588,6 +604,8 @@ class Pregel(val graph: GraphFrame)
       }
     }
 
+    graph.spark.sparkContext.setJobDescription(
+      s"$getJobDescriptionPrefix: materializing final result")
     val res = currentVertices.persist(intermediateStorageLevel)
     res.count()
     while (lastRoundPersistent.nonEmpty) {

--- a/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
+++ b/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
@@ -15,6 +15,7 @@ import org.graphframes.GraphFrame.LONG_DST
 import org.graphframes.GraphFrame.LONG_ID
 import org.graphframes.GraphFrame.LONG_SRC
 import org.graphframes.GraphFrame.SRC
+import org.graphframes.JobDescription
 import org.graphframes.Logging
 
 import java.io.IOException
@@ -57,6 +58,8 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
     val sc = spark.sparkContext
     val runId = UUID.randomUUID().toString.takeRight(8)
     val logPrefix = s"[CC $runId]"
+    val jobDescriptionPrefix = s"GraphFrames ConnectedComponents [$runId]"
+    val previousJobDescription = sc.getLocalProperty(JobDescription.JOB_DESCRIPTION_KEY)
 
     val checkpointDir = sc.getCheckpointDir
       .map { d =>
@@ -100,6 +103,7 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
     def axpb(a: Long, x: Column, b: Long): Column = call_function("_axpb", lit(a), x, lit(b))
 
     try {
+      sc.setJobDescription(s"$jobDescriptionPrefix: preparing graph")
       var rA = 0L
       var graphSize = edges.count()
       var ccRepresentatives: DataFrame = null
@@ -117,6 +121,7 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
 
       while (graphSize > 0) {
         logInfo(s"iteration ${iter}, edges left ${graphSize}")
+        sc.setJobDescription(s"$jobDescriptionPrefix: iteration $iter, $graphSize edges left")
         iter += 1
         rA = 0L
         while (rA == 0L) {
@@ -177,6 +182,7 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
 
       while (iter > 1) {
         iter -= 1
+        sc.setJobDescription(s"$jobDescriptionPrefix: reverse transformation step $iter")
         val poppedA = stackA.pop()
         val poppedB = stackB.pop()
 
@@ -248,6 +254,7 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
               .alias(ConnectedComponents.COMPONENT))
       }
 
+      sc.setJobDescription(s"$jobDescriptionPrefix: materializing final result")
       outputComponents.persist(intermediateStorageLevel)
       // materialize to be able to clean up everything
       outputComponents.count()
@@ -261,6 +268,7 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
 
       outputComponents
     } finally {
+      sc.setLocalProperty(JobDescription.JOB_DESCRIPTION_KEY, previousJobDescription)
       // to be 100% sure;
       edges.unpersist()
       val dereg = functionRegistry.dropFunction(FunctionIdentifier("_axpb"))

--- a/core/src/main/scala/org/graphframes/lib/ShortestPaths.scala
+++ b/core/src/main/scala/org/graphframes/lib/ShortestPaths.scala
@@ -215,6 +215,7 @@ private object ShortestPaths extends Logging {
     // 2. If new message can improve distances send it
     // 3. Collect and aggregate messages
     val pregel = preparedGraph.pregel
+      .setJobDescriptionPrefix("GraphFrames ShortestPaths")
       .setIntermediateStorageLevel(intermediateStorageLevel)
       .setMaxIter(Int.MaxValue) // That is how the GraphX implementation works
       .withVertexColumn(

--- a/core/src/main/scala/org/graphframes/lib/StructureAwareLabelPropagation.scala
+++ b/core/src/main/scala/org/graphframes/lib/StructureAwareLabelPropagation.scala
@@ -181,6 +181,7 @@ class StructureAwareLabelPropagation private[graphframes] (private val graph: Gr
     val pregel = preparedGraph.pregel
 
     pregel
+      .setJobDescriptionPrefix("GraphFrames StructureAwareLabelPropagation")
       .setMaxIter(maxIterChecked)
       .setCheckpointInterval(checkpointInterval)
       .setUseLocalCheckpoints(useLocalCheckpoints)

--- a/core/src/main/scala/org/graphframes/lib/TwoPhase.scala
+++ b/core/src/main/scala/org/graphframes/lib/TwoPhase.scala
@@ -31,6 +31,7 @@ import org.graphframes.GraphFrame.LONG_DST
 import org.graphframes.GraphFrame.LONG_ID
 import org.graphframes.GraphFrame.LONG_SRC
 import org.graphframes.GraphFrame.SRC
+import org.graphframes.JobDescription
 import org.graphframes.Logging
 
 import java.io.IOException
@@ -259,6 +260,7 @@ private[graphframes] object TwoPhase extends Logging {
     val spark = graph.spark
     val sc = spark.sparkContext
     val originalAQE = spark.conf.get("spark.sql.adaptive.enabled")
+    val previousJobDescription = sc.getLocalProperty(JobDescription.JOB_DESCRIPTION_KEY)
 
     try {
       spark.conf.set("spark.sql.adaptive.enabled", "false")
@@ -266,6 +268,8 @@ private[graphframes] object TwoPhase extends Logging {
       val runId = UUID.randomUUID().toString.takeRight(8)
       val logPrefix = s"[CC $runId]"
       logInfo(s"$logPrefix Start connected components with run ID $runId.")
+      val jobDescriptionPrefix = s"GraphFrames ConnectedComponents [$runId]"
+      sc.setJobDescription(s"$jobDescriptionPrefix: preparing graph")
 
       val shouldCheckpoint = checkpointInterval > 0
       val checkpointDir: Option[String] = if (useLocalCheckpoints) { None }
@@ -314,6 +318,7 @@ private[graphframes] object TwoPhase extends Logging {
 
       var lastRoundPersistedDFs = Seq[DataFrame](ee, minNbrs1)
       while (!converged) {
+        sc.setJobDescription(s"$jobDescriptionPrefix: iteration $iteration")
         var currRoundPersistedDFs = Seq[DataFrame]()
 
         // large-star step
@@ -430,6 +435,7 @@ private[graphframes] object TwoPhase extends Logging {
       logInfo(s"$logPrefix Connected components converged in ${iteration - 1} iterations.")
       logInfo(s"$logPrefix Join and return component assignments with original vertex IDs.")
 
+      sc.setJobDescription(s"$jobDescriptionPrefix: materializing final result")
       val output = buildOutput(graph, vv, ee, useLabelsAsComponents)
         .persist(intermediateStorageLevel)
 
@@ -447,6 +453,7 @@ private[graphframes] object TwoPhase extends Logging {
       output
     } finally {
       spark.conf.set("spark.sql.adaptive.enabled", originalAQE)
+      sc.setLocalProperty(JobDescription.JOB_DESCRIPTION_KEY, previousJobDescription)
     }
   }
 
@@ -464,11 +471,37 @@ private[graphframes] object TwoPhase extends Logging {
       isGraphPrepared: Boolean,
       optStartIter: Int = 2,
       sparsityThreshold: Double = 2.0,
-      shrinkageThreshold: Double = 2.0): DataFrame = {
+      shrinkageThreshold: Double = 2.0): DataFrame =
+    JobDescription.withRestoredJobDescription(graph.spark) {
+      runAQEInternal(
+        graph,
+        checkpointInterval,
+        intermediateStorageLevel,
+        useLabelsAsComponents,
+        useLocalCheckpoints,
+        isGraphPrepared,
+        optStartIter,
+        sparsityThreshold,
+        shrinkageThreshold)
+    }
 
+  private def runAQEInternal(
+      graph: GraphFrame,
+      checkpointInterval: Int,
+      intermediateStorageLevel: StorageLevel,
+      useLabelsAsComponents: Boolean,
+      useLocalCheckpoints: Boolean,
+      isGraphPrepared: Boolean,
+      optStartIter: Int,
+      sparsityThreshold: Double,
+      shrinkageThreshold: Double): DataFrame = {
+
+    val sc = graph.spark.sparkContext
     val runId = UUID.randomUUID().toString.takeRight(8)
     val logPrefix = s"[CC $runId]"
     logInfo(s"$logPrefix Start connected components with run ID $runId.")
+    val jobDescriptionPrefix = s"GraphFrames ConnectedComponents [$runId]"
+    sc.setJobDescription(s"$jobDescriptionPrefix: preparing graph")
 
     val shouldCheckpoint = checkpointInterval > 0
 
@@ -497,6 +530,7 @@ private[graphframes] object TwoPhase extends Logging {
 
     var lastRoundPersistedDFs = Seq[DataFrame](ee, minNbrs1)
     while (!converged) {
+      sc.setJobDescription(s"$jobDescriptionPrefix: iteration $iteration")
       var currRoundPersistedDFs = Seq[DataFrame]()
 
       // large-star step
@@ -603,6 +637,7 @@ private[graphframes] object TwoPhase extends Logging {
     logInfo(s"$logPrefix Connected components converged in ${iteration - 1} iterations.")
     logInfo(s"$logPrefix Join and return component assignments with original vertex IDs.")
 
+    sc.setJobDescription(s"$jobDescriptionPrefix: materializing final result")
     val output = buildOutput(graph, vv, ee, useLabelsAsComponents)
       .persist(intermediateStorageLevel)
 

--- a/core/src/main/scala/org/graphframes/mixins.scala
+++ b/core/src/main/scala/org/graphframes/mixins.scala
@@ -1,6 +1,57 @@
 package org.graphframes
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.storage.StorageLevel
+
+private[graphframes] object JobDescription {
+  // Mirrors SparkContext.SPARK_JOB_DESCRIPTION, which is private[spark].
+  private[graphframes] val JOB_DESCRIPTION_KEY = "spark.job.description"
+
+  /**
+   * Runs `body` and afterwards restores the Spark job description (a thread-local property) that
+   * the caller had set, so descriptions set inside `body` do not leak into jobs the caller
+   * triggers later on the same thread.
+   */
+  def withRestoredJobDescription[T](spark: SparkSession)(body: => T): T = {
+    val sc = spark.sparkContext
+    val previousDescription = sc.getLocalProperty(JOB_DESCRIPTION_KEY)
+    try {
+      body
+    } finally {
+      sc.setLocalProperty(JOB_DESCRIPTION_KEY, previousDescription)
+    }
+  }
+}
+
+/**
+ * Provides support for customizing the Spark job descriptions set by iterative algorithms.
+ *
+ * Job descriptions are shown in the "Description" column of the Jobs and Stages pages of the
+ * Spark UI, making the progress of long iterative runs visible without reading driver logs.
+ */
+private[graphframes] trait WithJobDescriptionPrefix {
+
+  /** The prefix used when no custom prefix is set, typically the algorithm name. */
+  protected def defaultJobDescriptionPrefix: String
+
+  protected var jobDescriptionPrefixOpt: Option[String] = None
+
+  /**
+   * Sets a custom prefix for the Spark job descriptions set by this algorithm (default: the
+   * algorithm name). Setting distinct prefixes allows telling apart multiple concurrent runs
+   * within the same Spark application.
+   */
+  def setJobDescriptionPrefix(value: String): this.type = {
+    jobDescriptionPrefixOpt = Some(value)
+    this
+  }
+
+  /**
+   * Gets the prefix of the Spark job descriptions set by this algorithm.
+   */
+  def getJobDescriptionPrefix: String =
+    jobDescriptionPrefixOpt.getOrElse(defaultJobDescriptionPrefix)
+}
 
 private[graphframes] trait WithAlgorithmChoice {
   protected val ALGO_GRAPHX = "graphx"

--- a/core/src/main/scala/org/graphframes/rw/RandomWalkBase.scala
+++ b/core/src/main/scala/org/graphframes/rw/RandomWalkBase.scala
@@ -16,8 +16,10 @@ import org.apache.spark.sql.graphframes.expressions.KMinSampling
 import org.apache.spark.sql.types.ArrayType
 import org.apache.spark.sql.types.DataType
 import org.graphframes.GraphFrame
+import org.graphframes.JobDescription
 import org.graphframes.Logging
 import org.graphframes.WithIntermediateStorageLevel
+import org.graphframes.WithJobDescriptionPrefix
 
 import scala.util.Random
 
@@ -25,7 +27,13 @@ import scala.util.Random
  * Base trait for implementing random walk algorithms on graph data. Provides common functionality
  * for generating random walks across a graph structure.
  */
-trait RandomWalkBase extends Serializable with Logging with WithIntermediateStorageLevel {
+trait RandomWalkBase
+    extends Serializable
+    with Logging
+    with WithIntermediateStorageLevel
+    with WithJobDescriptionPrefix {
+
+  override protected def defaultJobDescriptionPrefix: String = "GraphFrames RandomWalk"
 
   /** Maximum number of neighbors to consider per vertex during random walks. */
   protected var maxNbrs: Int = 50
@@ -243,6 +251,12 @@ trait RandomWalkBase extends Serializable with Logging with WithIntermediateStor
       throw new IllegalArgumentException("Temporary prefix is required for random walks.")
     }
 
+    JobDescription.withRestoredJobDescription(graph.vertices.sparkSession) {
+      runBatches()
+    }
+  }
+
+  private def runBatches(): DataFrame = {
     logInfo(s"Starting random walk with runID: $runID")
 
     val iterationsRng = new Random(globalSeed)
@@ -259,6 +273,8 @@ trait RandomWalkBase extends Serializable with Logging with WithIntermediateStor
 
     for (i <- startingIteration to numBatches) {
       logInfo(s"Starting batch $i of $numBatches")
+      spark.sparkContext.setJobDescription(
+        s"$getJobDescriptionPrefix [$runID]: batch $i of $numBatches")
       val iterSeed = iterationsRng.nextLong()
       val preparedGraph = prepareGraph(iterSeed)
       val prevIterationDF = if (i == 1) { None }
@@ -271,6 +287,8 @@ trait RandomWalkBase extends Serializable with Logging with WithIntermediateStor
     }
 
     logInfo("Finished all batches, merging results.")
+    spark.sparkContext.setJobDescription(
+      s"$getJobDescriptionPrefix [$runID]: materializing final result")
 
     val result = (1 to numBatches)
       .map(i => spark.read.parquet(iterationTmpPath(i)))

--- a/core/src/main/scala/org/graphframes/rw/RandomWalkWithRestart.scala
+++ b/core/src/main/scala/org/graphframes/rw/RandomWalkWithRestart.scala
@@ -17,6 +17,8 @@ import org.graphframes.GraphFrame
  */
 class RandomWalkWithRestart extends RandomWalkBase {
 
+  override protected def defaultJobDescriptionPrefix: String = "GraphFrames RandomWalkWithRestart"
+
   /** The probability of restarting the walk at each step (resets to starting node). */
   private var restartProbability: Double = 0.1
 

--- a/core/src/test/scala/org/graphframes/lib/JobDescriptionSuite.scala
+++ b/core/src/test/scala/org/graphframes/lib/JobDescriptionSuite.scala
@@ -128,6 +128,48 @@ class JobDescriptionSuite extends SparkFunSuite with GraphFrameTestSparkContext 
     assert(descriptions.exists(_.startsWith("GraphFrames ShortestPaths: iteration 1")))
   }
 
+  test("maximal independent set sets job descriptions and restores the caller's") {
+    sc.setJobDescription("caller description")
+    try {
+      val descriptions = capturedDescriptionsDuring {
+        val _ = chainGraph().maximalIndependentSet.run(seed = 12345L)
+      }(_.contains("GraphFrames MaximalIndependentSet: materializing final result"))
+
+      assert(descriptions.exists(_.startsWith("GraphFrames MaximalIndependentSet: iteration ")))
+      assert(sc.getLocalProperty(descriptionKey) === "caller description")
+    } finally {
+      sc.setLocalProperty(descriptionKey, null)
+    }
+  }
+
+  test("random walks set per-batch job descriptions and restore the caller's") {
+    val temporaryPrefix = java.nio.file.Files.createTempDirectory("rw-job-descriptions").toString
+    val rwRunner = new org.graphframes.rw.RandomWalkWithRestart()
+      .onGraph(chainGraph())
+      .setNumBatches(2)
+      .setBatchSize(2)
+      .setNumWalksPerNode(1)
+      .setTemporaryPrefix(temporaryPrefix)
+
+    sc.setJobDescription("caller description")
+    try {
+      val descriptions = capturedDescriptionsDuring {
+        val _ = rwRunner.run()
+      }(_.exists(_.endsWith(": materializing final result")))
+
+      assert(descriptions.exists(d =>
+        d.startsWith("GraphFrames RandomWalkWithRestart [") && d.endsWith(": batch 1 of 2")))
+      assert(
+        descriptions.exists(d =>
+          d.startsWith("GraphFrames RandomWalkWithRestart [")
+            && d.endsWith(": materializing final result")))
+      assert(sc.getLocalProperty(descriptionKey) === "caller description")
+    } finally {
+      sc.setLocalProperty(descriptionKey, null)
+      rwRunner.cleanUp()
+    }
+  }
+
   // broadcastThreshold -1 selects the AQE-based two-phase implementation
   Seq(("two_phase", 1000000), ("two_phase", -1), ("randomized_contraction", 1000000)).foreach {
     case (algorithm, broadcastThreshold) =>

--- a/core/src/test/scala/org/graphframes/lib/JobDescriptionSuite.scala
+++ b/core/src/test/scala/org/graphframes/lib/JobDescriptionSuite.scala
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.graphframes.lib
+
+import org.apache.spark.scheduler.SparkListener
+import org.apache.spark.scheduler.SparkListenerJobStart
+import org.apache.spark.sql.functions.*
+import org.graphframes.*
+
+import scala.collection.mutable
+
+class JobDescriptionSuite extends SparkFunSuite with GraphFrameTestSparkContext {
+
+  import sqlImplicits.*
+
+  private val descriptionKey = "spark.job.description"
+
+  private def chainGraph(n: Int = 5): GraphFrame = {
+    val vertices = (1 to n).toDF("id")
+    val edges = (1 until n).map(x => (x, x + 1)).toDF("src", "dst")
+    GraphFrame(vertices, edges)
+  }
+
+  private def propagationPregel(graph: GraphFrame, maxIter: Int): Pregel = graph.pregel
+    .setMaxIter(maxIter)
+    .withVertexColumn(
+      "value",
+      when(col("id") === lit(1), lit(1)).otherwise(lit(0)),
+      greatest(col("value"), coalesce(Pregel.msg, lit(0))))
+    .sendMsgToDst(Pregel.src("value"))
+    .aggMsgs(max(Pregel.msg))
+
+  /**
+   * Collects the job descriptions of all jobs started while running `body`. Listener events are
+   * delivered asynchronously, so after `body` completes this polls until `await` is satisfied by
+   * the captured descriptions (or a timeout is reached).
+   */
+  private def capturedDescriptionsDuring(body: => Unit)(
+      await: Seq[String] => Boolean): Seq[String] = {
+    val captured = mutable.ArrayBuffer.empty[String]
+    val listener = new SparkListener {
+      override def onJobStart(jobStart: SparkListenerJobStart): Unit = {
+        val description = jobStart.properties.getProperty(descriptionKey)
+        if (description != null) {
+          captured.synchronized {
+            val _ = captured += description
+          }
+        }
+      }
+    }
+    sc.addSparkListener(listener)
+    try {
+      body
+      val deadline = System.currentTimeMillis() + 30000L
+      while (System.currentTimeMillis() < deadline
+        && !captured.synchronized(await(captured.toSeq))) {
+        Thread.sleep(50)
+      }
+      captured.synchronized(captured.toSeq)
+    } finally {
+      sc.removeSparkListener(listener)
+    }
+  }
+
+  test("Pregel sets a job description for each iteration") {
+    val descriptions = capturedDescriptionsDuring {
+      val _ = propagationPregel(chainGraph(), maxIter = 2).run()
+    }(_.contains("GraphFrames Pregel: materializing final result"))
+
+    assert(descriptions.contains("GraphFrames Pregel: iteration 1 / 2"))
+    assert(descriptions.contains("GraphFrames Pregel: iteration 2 / 2"))
+    assert(descriptions.contains("GraphFrames Pregel: materializing final result"))
+  }
+
+  test("Pregel job description prefix is configurable") {
+    val descriptions = capturedDescriptionsDuring {
+      val _ = propagationPregel(chainGraph(), maxIter = 1)
+        .setJobDescriptionPrefix("my Pregel run")
+        .run()
+    }(_.contains("my Pregel run: materializing final result"))
+
+    assert(descriptions.contains("my Pregel run: iteration 1 / 1"))
+    assert(descriptions.forall(!_.startsWith("GraphFrames Pregel")))
+  }
+
+  test("Pregel restores the caller's job description") {
+    sc.setJobDescription("caller description")
+    try {
+      val vertices = propagationPregel(chainGraph(), maxIter = 1).run()
+      assert(vertices.count() === 5)
+      assert(sc.getLocalProperty(descriptionKey) === "caller description")
+
+      // The description must be restored on failures as well.
+      val _ = intercept[Exception] {
+        propagationPregel(chainGraph(), maxIter = 1)
+          .aggMsgs(max(col("nonexistent")))
+          .run()
+      }
+      assert(sc.getLocalProperty(descriptionKey) === "caller description")
+    } finally {
+      sc.setLocalProperty(descriptionKey, null)
+    }
+  }
+
+  test("Pregel-based algorithms set their own job description prefix") {
+    val descriptions = capturedDescriptionsDuring {
+      val _ = chainGraph().shortestPaths
+        .landmarks(Seq(5))
+        .setAlgorithm("graphframes")
+        .run()
+    }(_.exists(_.startsWith("GraphFrames ShortestPaths: iteration")))
+
+    assert(descriptions.exists(_.startsWith("GraphFrames ShortestPaths: iteration 1")))
+  }
+
+  // broadcastThreshold -1 selects the AQE-based two-phase implementation
+  Seq(("two_phase", 1000000), ("two_phase", -1), ("randomized_contraction", 1000000)).foreach {
+    case (algorithm, broadcastThreshold) =>
+      test(
+        s"connected components ($algorithm, broadcastThreshold=$broadcastThreshold) " +
+          "sets job descriptions and restores the caller's") {
+        sc.setJobDescription("caller description")
+        try {
+          val descriptions = capturedDescriptionsDuring {
+            val _ = chainGraph().connectedComponents
+              .setAlgorithm(algorithm)
+              .setBroadcastThreshold(broadcastThreshold)
+              .run()
+          }(_.exists(_.contains(": materializing final result")))
+
+          assert(descriptions.exists(d =>
+            d.startsWith("GraphFrames ConnectedComponents [") && d.contains(": iteration ")))
+          assert(
+            descriptions.exists(d =>
+              d.startsWith("GraphFrames ConnectedComponents [")
+                && d.endsWith(": materializing final result")))
+          assert(sc.getLocalProperty(descriptionKey) === "caller description")
+        } finally {
+          sc.setLocalProperty(descriptionKey, null)
+        }
+      }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Iterative algorithms now set a Spark job description before triggering the actions of each iteration, so the Jobs and Stages pages of the Spark UI show entries like `GraphFrames Pregel: iteration 7 / 20` instead of indistinguishable generic names:

- **`Pregel.run()`** sets `<prefix>: iteration <i> / <maxIter>` per iteration (the ` / <maxIter>` part is omitted when `maxIter == Int.MaxValue`, as used by algorithms that rely on early stopping) and `<prefix>: materializing final result` for the final materialization. The prefix defaults to `GraphFrames Pregel` and is configurable via a new `setJobDescriptionPrefix` builder method, so concurrent runs in one application can be told apart.
- **Pregel-based algorithms** (`ShortestPaths`, `LabelPropagation`, `StructureAwareLabelPropagation`, `KCore`, `DetectingCycles`) pass their own algorithm name as the prefix.
- **All three DataFrame-based connected components paths** (two-phase, two-phase AQE, randomized contraction) label their phases as `GraphFrames ConnectedComponents [<runId>]: preparing graph / iteration <i> / materializing final result`, reusing the run id that already appears in their driver logs so UI entries can be correlated with log lines.
- **`RandomWalkBase`** sets `<prefix> [<runID>]: batch <i> of <numBatches>` per batch — the prefix comes from a base-class override point, and `RandomWalkWithRestart` reports its own name — and **`MaximalIndependentSet`** labels each of its iterations (added on review request).

The caller's job description (a thread-local `SparkContext` property) is saved before a run and restored afterwards — including when the run fails — via a small `JobDescription.withRestoredJobDescription` helper in `mixins.scala`. Only the job *description* is set, never the job *group*, so applications that rely on `SparkContext.cancelJobGroup` for cancellation are unaffected.

Since this lives in the Scala core, it covers every API surface (Scala, PySpark classic, both Spark Connect paths) — the descriptions are set on the JVM driver, where the algorithms execute.

Not covered here, possible follow-ups: the GraphX-backed algorithm paths, single-action algorithms (BFS, AggregateMessages, ...), and exposing `setJobDescriptionPrefix` through the PySpark/Connect Pregel builders.

Tested by the new `JobDescriptionSuite`, which uses a `SparkListener` to assert that per-iteration descriptions are attached to the jobs of Pregel runs (default and custom prefix), a Pregel-based algorithm (`ShortestPaths`), all three DataFrame connected components paths, `MaximalIndependentSet`, and `RandomWalkWithRestart`, and that the caller's description is restored after both successful and failing runs.

### Why are the changes needed?

Closes #797. On a long iterative run today every Spark job looks identical in the UI, so there is no way to tell iteration 2 from iteration 40 — or a healthy run from a stuck one — without parsing driver logs.
