### PR TITLE
fix: use qualified function identifiers for temp functions

### DIFF
--- a/core/src/main/scala/org/graphframes/lib/KCore.scala
+++ b/core/src/main/scala/org/graphframes/lib/KCore.scala
@@ -65,14 +65,15 @@ object KCore extends Serializable with Logging {
       storageLevel: StorageLevel,
       checkpointInterval: Int,
       useLocalCheckpoints: Boolean): DataFrame = {
+    val spark = graph.vertices.sparkSession
     val degrees = graph.degrees
     val preparedGraph = GraphFrame(
       degrees.withColumn("degree", col("degree").cast(IntegerType)),
       graph.edges.select(GraphFrame.SRC, GraphFrame.DST))
 
-    val functionRegistry = graph.vertices.sparkSession.sessionState.functionRegistry
-    functionRegistry.registerFunction(
-      FunctionIdentifier("_kcoreMerge"),
+    val functionRegistry = spark.sessionState.functionRegistry
+    functionRegistry.createOrReplaceTempFunction(
+      "_kcoreMerge",
       (children: Seq[Expression]) => KCoreMerge(children(0), children(1)),
       "scala_udf")
 
@@ -98,7 +99,8 @@ object KCore extends Serializable with Logging {
 
       pregel.run()
     } finally {
-      val dereg = functionRegistry.dropFunction(FunctionIdentifier("_kcoreMerge"))
+      val catalog = spark.sessionState.catalog
+      val dereg = catalog.unregisterFunction(FunctionIdentifier("_kcoreMerge"))
       if (!dereg) {
         logWarn(
           "graphframes faced an internal error and was not able to de-register function _kcoreMerge; Spark' functionRegistry is in a bad state")

--- a/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
+++ b/core/src/main/scala/org/graphframes/lib/RandomizedContraction.scala
@@ -77,8 +77,8 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
     logInfo(s"$logPrefix Using $checkpointDir for storing intermediate tables.")
 
     val functionRegistry = spark.sessionState.functionRegistry
-    functionRegistry.registerFunction(
-      FunctionIdentifier("_axpb"),
+    functionRegistry.createOrReplaceTempFunction(
+      "_axpb",
       (children: Seq[Expression]) => FiniteAXPlusB(children(0), children(1), children(2)),
       "scala_udf")
 
@@ -302,7 +302,8 @@ private[graphframes] object RandomizedContraction extends Logging with Serializa
       // to be 100% sure;
       edges.unpersist()
       cleanupCheckpointDir()
-      val dereg = functionRegistry.dropFunction(FunctionIdentifier("_axpb"))
+      val catalog = spark.sessionState.catalog
+      val dereg = catalog.unregisterFunction(FunctionIdentifier("_axpb"))
       if (!dereg) {
         logWarn(
           "graphframes faced an internal error and was not able to de-register function _axpb; Spark' functionRegistry is in a bad state")

--- a/core/src/test/scala/org/graphframes/lib/RandomizedContractionSuite.scala
+++ b/core/src/test/scala/org/graphframes/lib/RandomizedContractionSuite.scala
@@ -280,8 +280,7 @@ class RandomizedContractionSuite extends SparkFunSuite with GraphFrameTestSparkC
   }
 
   private def assertFunctionRegistryClean(): Unit = {
-    val functionRegistry = spark.sessionState.functionRegistry
-    val _ = assert(!functionRegistry.functionExists(FunctionIdentifier("_axpb")))
+    val _ = assert(!spark.sessionState.catalog.isTemporaryFunction(FunctionIdentifier("_axpb")))
   }
 
   private def listParquetFiles(): Set[String] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
`RandomizedContraction` and `KCore` algorithms register temporary functions `_axpb` and `_kcoreMerge` by calling `functionRegistry.registerFunction` with `FunctionIdentifier` objects with a function name string. This PR switches registration to `functionRegistry.createOrReplaceTempFunction` which takes a plain name and applies the correct temporary qualifications (database and catalog) and de-registration to `SessionCatalog.unregisterFunction` which resolves the unqualified identifier the same way.

### Why are the changes needed?
We hit this running `connectedComponents` using the `RandomizedContraction` algorithm on Spark 4.2:

```
[info]   java.lang.AssertionError: assertion failed: Function identifier must be fully qualified (3-part): _axpb
[info]   at scala.Predef$.assert(Predef.scala:279)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistryBase.normalizeFuncName(FunctionRegistry.scala:225)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistryBase.normalizeFuncName$(FunctionRegistry.scala:223)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry.normalizeFuncName(FunctionRegistry.scala:331)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistryBase.registerFunction(FunctionRegistry.scala:236)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistryBase.registerFunction$(FunctionRegistry.scala:232)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry.registerFunction(FunctionRegistry.scala:331)
[info]   at org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase.registerFunction(FunctionRegistry.scala:71)
[info]   at org.apache.spark.sql.catalyst.analysis.FunctionRegistryBase.registerFunction$(FunctionRegistry.scala:56)
[info]   at org.apache.spark.sql.catalyst.analysis.SimpleFunctionRegistry.registerFunction(FunctionRegistry.scala:331)
[info]   ...
```

This can be reproduced by running the test suites using 4.2.0: `./build/sbt -Dspark.version=4.2.0 "testOnly *RandomizedContractionSuite *KCoreSuite"`. NOTE: I had to remove the legacy `log4j.logger.*` entries from `core/src/test/resources/log4j2.properties` in order to test on 4.2.0.

This assert statement was introduced in https://github.com/apache/spark/pull/54765 to prevent unqualified functions shadowing and colliding with builtin or session functions. The change requires all function identifiers to be fully qualified with the three keys: name, database, and catalog: https://github.com/apache/spark/blob/2a7cfea06ba135cf0ddc62902eb0daf5a835c672/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala#L225

CI doesn't catch this yet because the matrix covers 3.5, 4.0, and 4.1. The fix works on all currently supported versions. `createOrReplaceTempFunction` registers under a plain string on 3.5/4.0/4.1 and under the qualified one on 4.2. `unregisterFunction` matches directly on the older versions, and on 4.2 re-qualifies via `tempFunctionIdentifier` when the database is empty.

I verified with `testOnly *RandomizedContractionSuite *KCoreSuite` against the Spark versions 3.5.8, 4.0.3, 4.1.2 and 4.2.0 and `test` against the versions only in the CI test matrix.